### PR TITLE
add .swp to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# text editor tmp files
+.*.swp
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Vim creates tmp files named `.*.swp`.  Git shouldn't track them.

Also I'm testing pull requesting