### PR TITLE
fix units on GMsun

### DIFF
--- a/enterprise/constants.py
+++ b/enterprise/constants.py
@@ -37,7 +37,7 @@ Mpc = pc * 1.e6
 Gpc = pc * 1.e9
 
 # solar mass in kg and m,s natural units
-GMsun = 1.327124400e11  # measured more precisely than Msun alone!
+GMsun = 1.327124400e20  # measured more precisely than Msun alone!
 Msun = GMsun / G
 Rsun = GMsun / (c**2)
 Tsun = GMsun / (c**3)


### PR DESCRIPTION
GMsun was originally `...e11` which is in km^3/s^2.  Set to `...e20` for m^3/s^2