### PR TITLE
New ECORR signal models

### DIFF
--- a/enterprise/pulsar.py
+++ b/enterprise/pulsar.py
@@ -24,7 +24,7 @@ except ImportError:
 class Pulsar(object):
 
     def __init__(self, parfile, timfile, maxobs=30000, ephem=None,
-                 planets=True):
+                 planets=True, sort=True):
         # Check whether the two files exist
         if not os.path.isfile(parfile) or not os.path.isfile(timfile):
             msg = 'Cannot find parfile {0} or timfile {1}!'.format(
@@ -43,6 +43,9 @@ class Pulsar(object):
         # Change directory to the base directory of the tim-file to deal with
         # INCLUDE statements in the tim-file
         os.chdir(dirname)
+
+        # sorting
+        self._sort = sort
 
         # Load pulsar data from the libstempo library
         # TODO: make sure we specify libstempo>=2.3.1
@@ -176,6 +179,20 @@ class Pulsar(object):
             self._planetssb[:, 7, :] = self.t2pulsar.neptune_ssb
             self._planetssb[:, 8, :] = self.t2pulsar.pluto_ssb
 
+        # sorting
+        self.sort_data()
+
+    def sort_data(self):
+        """Sort data by time."""
+        if self._sort:
+            self._isort = np.argsort(self._toas, kind='mergesort')
+            self._iisort = np.zeros(len(self._isort), dtype=np.int)
+            for ii, p in enumerate(self._isort):
+                self._iisort[p] = ii
+        else:
+            self._isort = slice(None, None, None)
+            self._iisort = slice(None, None, None)
+
     def filter_data(self, start_time=None, end_time=None):
         """Filter data to create a time-slice of overall dataset."""
         if start_time is None and end_time is None:
@@ -199,6 +216,8 @@ class Pulsar(object):
         if self._planetssb is not None:
             self._planetssb = self.planetssb[mask, :, :]
 
+        self.sort_data()
+
     def to_pickle(self, savedir):
         """Save object to pickle file."""
 
@@ -207,29 +226,39 @@ class Pulsar(object):
         pass
 
     @property
+    def isort(self):
+        """Return sorting indices."""
+        return self._isort
+
+    @property
+    def iisort(self):
+        """Return inverse of sorting indices."""
+        return self._iisort
+
+    @property
     def toas(self):
         """Return array of TOAs in seconds."""
-        return self._toas
+        return self._toas[self._isort]
 
     @property
     def residuals(self):
         """Return array of residuals in seconds."""
-        return self._residuals
+        return self._residuals[self._isort]
 
     @property
     def toaerrs(self):
         """Return array of TOA errors in seconds."""
-        return self._toaerrs
+        return self._toaerrs[self._isort]
 
     @property
     def freqs(self):
         """Return array of radio frequencies in MHz."""
-        return self._ssbfreqs
+        return self._ssbfreqs[self._isort]
 
     @property
     def Mmat(self):
         """Return ntoa x npar design matrix."""
-        return self._designmatrix
+        return self._designmatrix[self._isort, :]
 
     @property
     def pdist(self):
@@ -239,7 +268,8 @@ class Pulsar(object):
     @property
     def flags(self):
         """Return a dictionary of tim-file flags."""
-        return self._flags
+
+        return dict((k, v[self._isort]) for k, v in self._flags.items())
 
     @property
     def backend_flags(self):
@@ -261,7 +291,7 @@ class Pulsar(object):
                 if np.all(map(lambda xx: check(ii, xx), f)):
                     bflags[ii] = '_'.join(self._flags[x][ii] for x in f)
                     break
-        return np.array(bflags)
+        return np.array(bflags)[self._isort]
 
     @property
     def theta(self):

--- a/enterprise/pulsar.py
+++ b/enterprise/pulsar.py
@@ -26,7 +26,7 @@ class Pulsar(object):
 
     def __init__(self, parfile, timfile, maxobs=30000, ephem=None,
                  planets=True, sort=True, drop_t2pulsar=True):
-                 
+
         # Check whether the two files exist
         if not os.path.isfile(parfile) or not os.path.isfile(timfile):
             msg = 'Cannot find parfile {0} or timfile {1}!'.format(

--- a/enterprise/signals/gp_signals.py
+++ b/enterprise/signals/gp_signals.py
@@ -17,8 +17,7 @@ from enterprise.signals.selections import Selection
 
 
 def FourierBasisGP(spectrum, components=20,
-                   selection=Selection(selections.no_selection),
-                   Tspan=None):
+                   selection=Selection(selections.no_selection), Tspan=None):
     """Class factory for fourier basis GPs."""
 
     class FourierBasisGP(base.Signal):

--- a/enterprise/signals/gp_signals.py
+++ b/enterprise/signals/gp_signals.py
@@ -17,7 +17,8 @@ from enterprise.signals.selections import Selection
 
 
 def FourierBasisGP(spectrum, components=20,
-                   selection=Selection(selections.no_selection), Tspan=None):
+                   selection=Selection(selections.no_selection),
+                   Tspan=None):
     """Class factory for fourier basis GPs."""
 
     class FourierBasisGP(base.Signal):
@@ -196,7 +197,6 @@ def FourierBasisCommonGP(crossspectrum=None, components=20,
 
         @classmethod
         def get_phicross(cls, signal1, signal2, params):
-            # currently pass the pulsar objects, what else could we do?
             # note multiplying by f[0] is not general
             return FourierBasisCommonGP._crossspectrum(
                 signal1._f2, signal1._psrpos, signal2._psrpos,

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -332,10 +332,17 @@ class csc_matrix_alt(scipy.sparse.csc_matrix):
 
     def __add__(self, other):
 
-        if isinstance(other, np.ndarray) and other.ndim == 1:
+        if isinstance(other, (np.ndarray, ndarray_alt)) and other.ndim == 1:
             return self._add_diag(other)
         else:
             return super(csc_matrix_alt, self).__add__(other)
+
+    # hacky way to fix adding ndarray on left
+    def __radd__(self, other):
+        if isinstance(other, (np.ndarray, ndarray_alt)) or other == 0:
+            return self.__add__(other)
+        else:
+            raise TypeError
 
     def solve(self, other, left_array=None, logdet=False):
         cf = cholesky(self)
@@ -409,7 +416,7 @@ class ShermanMorrison(object):
         """
 
         Nx = x / self._nvec
-        yNx = y * Nx
+        yNx = np.dot(y, Nx)
         for cc, jv in enumerate(self._jvec):
             if self._slices[cc].stop - self._slices[cc].start > 1:
                 xblock = x[self._slices[cc]]

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -402,12 +402,11 @@ class ShermanMorrison(object):
         """Solves :math:`N^{-1}x` where :math:`x` is a vector."""
 
         Nx = x / self._nvec
-        for cc, jv in enumerate(self._jvec):
-            if self._slices[cc].stop - self._slices[cc].start > 1:
-                rblock = x[self._slices[cc]]
-                niblock = 1 / self._nvec[self._slices[cc]]
-                beta = 1.0 / (np.einsum('i->', niblock)+1.0/jv)
-                Nx[self._slices[cc]] -= beta*np.dot(niblock, rblock)*niblock
+        for slc, jv in zip(self._slices, self._jvec):
+            rblock = x[slc]
+            niblock = 1 / self._nvec[slc]
+            beta = 1.0 / (np.einsum('i->', niblock) + 1.0/jv)
+            Nx[slc] -= beta * np.dot(niblock, rblock) * niblock
         return Nx
 
     def _solve_1D1(self, x, y):
@@ -417,13 +416,12 @@ class ShermanMorrison(object):
 
         Nx = x / self._nvec
         yNx = np.dot(y, Nx)
-        for cc, jv in enumerate(self._jvec):
-            if self._slices[cc].stop - self._slices[cc].start > 1:
-                xblock = x[self._slices[cc]]
-                yblock = y[self._slices[cc]]
-                niblock = 1 / self._nvec[self._slices[cc]]
-                beta = 1.0 / (np.einsum('i->', niblock)+1.0/jv)
-                yNx -= beta * np.dot(niblock, xblock) * np.dot(niblock, yblock)
+        for slc, jv in zip(self._slices, self._jvec):
+            xblock = x[slc]
+            yblock = y[slc]
+            niblock = 1 / self._nvec[slc]
+            beta = 1.0 / (np.einsum('i->', niblock)+1.0/jv)
+            yNx -= beta * np.dot(niblock, xblock) * np.dot(niblock, yblock)
         return yNx
 
     def _solve_2D2(self, X, Z):
@@ -432,15 +430,14 @@ class ShermanMorrison(object):
         """
 
         ZNX = np.dot(Z.T / self._nvec, X)
-        for cc, jv in enumerate(self._jvec):
-            if self._slices[cc].stop - self._slices[cc].start > 1:
-                Zblock = Z[self._slices[cc], :]
-                Xblock = X[self._slices[cc], :]
-                niblock = 1 / self._nvec[self._slices[cc]]
-                beta = 1.0 / (np.einsum('i->', niblock)+1.0/jv)
-                zn = np.dot(niblock, Zblock)
-                xn = np.dot(niblock, Xblock)
-                ZNX -= beta * np.outer(zn.T, xn)
+        for slc, jv in zip(self._slices, self._jvec):
+            Zblock = Z[slc, :]
+            Xblock = X[slc, :]
+            niblock = 1 / self._nvec[slc]
+            beta = 1.0 / (np.einsum('i->', niblock)+1.0/jv)
+            zn = np.dot(niblock, Zblock)
+            xn = np.dot(niblock, Xblock)
+            ZNX -= beta * np.outer(zn.T, xn)
         return ZNX
 
     def _get_logdet(self):
@@ -448,11 +445,10 @@ class ShermanMorrison(object):
         is a quantization matrix.
         """
         logdet = np.einsum('i->', np.log(self._nvec))
-        for cc, jv in enumerate(self._jvec):
-            if self._slices[cc].stop - self._slices[cc].start > 1:
-                niblock = 1 / self._nvec[self._slices[cc]]
-                beta = 1.0 / (np.einsum('i->', niblock)+1.0/jv)
-                logdet += np.log(jv) - np.log(beta)
+        for slc, jv in zip(self._slices, self._jvec):
+            niblock = 1 / self._nvec[slc]
+            beta = 1.0 / (np.einsum('i->', niblock)+1.0/jv)
+            logdet += np.log(jv) - np.log(beta)
         return logdet
 
     def solve(self, other, left_array=None, logdet=False):

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -10,7 +10,8 @@ import numpy as np
 import collections
 from itertools import combinations
 import six
-import scipy
+import scipy.sparse as sps
+import scipy.linalg as sl
 from sksparse.cholmod import cholesky
 
 from enterprise.signals.parameter import ConstantParameter
@@ -319,13 +320,13 @@ def Function(func, **kwargs):
     return Function
 
 
-class csc_matrix_alt(scipy.sparse.csc_matrix):
+class csc_matrix_alt(sps.csc_matrix):
     """Sub-class of ``scipy.sparse.csc_matrix`` with custom ``add`` and
     ``solve`` methods.
     """
 
     def _add_diag(self, other):
-        other_diag = scipy.sparse.dia_matrix(
+        other_diag = sps.dia_matrix(
             (other, np.array([0])),
             shape=(other.shape[0], other.shape[0]))
         return self._binopt(other_diag, '_plus_')
@@ -379,6 +380,94 @@ class ndarray_alt(np.ndarray):
         return ret
 
 
+class BlockMatrix(object):
+
+    def __init__(self, blocks, slices, nvec=0):
+        self._blocks = blocks
+        self._slices = slices
+        self._nvec = nvec
+
+    def __add__(self, other):
+        nvec = self._nvec + other
+        return BlockMatrix(self._blocks, self._slices, nvec)
+
+    # hacky way to fix adding 0
+    def __radd__(self, other):
+        if other == 0:
+            return self.__add__(other)
+        else:
+            raise TypeError
+
+    def _solve_ZNX(self, X, Z):
+        """Solves :math:`Z^T N^{-1}X`, where :math:`X`
+        and :math:`Z` are 1-d or 2-d arrays.
+        """
+        if X.ndim == 1:
+            X = X.reshape(X.shape[0], 1)
+        if Z.ndim == 1:
+            Z = Z.reshape(Z.shape[0], 1)
+
+        n, m = Z.shape[1], X.shape[1]
+        ZNX = np.zeros((n, m))
+        for slc, block in zip(self._slices, self._blocks):
+            Zblock = Z[slc, :]
+            Xblock = X[slc, :]
+
+            if slc.stop - slc.start > 1:
+                cf = sl.cho_factor(block+np.diag(self._nvec[slc]))
+                bx = sl.cho_solve(cf, Xblock)
+            else:
+                bx = Xblock / self._nvec[slc][:, None]
+            ZNX += np.dot(Zblock.T, bx)
+        return ZNX.squeeze() if len(ZNX) > 1 else float(ZNX)
+
+    def _solve_NX(self, X):
+        """Solves :math:`N^{-1}X`, where :math:`X`
+        is a 1-d or 2-d array.
+        """
+        if X.ndim == 1:
+            X = X.reshape(X.shape[0], 1)
+
+        m = X.shape[1]
+        NX = np.zeros((len(self._nvec), m))
+        for slc, block in zip(self._slices, self._blocks):
+            Xblock = X[slc, :]
+            if slc.stop - slc.start > 1:
+                cf = sl.cho_factor(block+np.diag(self._nvec[slc]))
+                NX[slc] = sl.cho_solve(cf, Xblock)
+            else:
+                NX[slc] = Xblock / self._nvec[slc][:, None]
+        return NX.squeeze()
+
+    def _get_logdet(self):
+        """Returns log determinant of :math:`N+UJU^{T}` where :math:`U`
+        is a quantization matrix.
+        """
+        logdet = 0
+        for slc, block in zip(self._slices, self._blocks):
+            if slc.stop - slc.start > 1:
+                cf = sl.cho_factor(block+np.diag(self._nvec[slc]))
+                logdet += np.sum(2*np.log(np.diag(cf[0])))
+            else:
+                logdet += np.sum(np.log(self._nvec[slc]))
+        return logdet
+
+    def solve(self, other, left_array=None, logdet=False):
+
+        if other.ndim not in [1, 2]:
+            raise TypeError
+        if left_array is not None:
+            if left_array.ndim not in [1, 2]:
+                raise TypeError
+
+        if left_array is not None:
+            ret = self._solve_ZNX(other, left_array)
+        else:
+            ret = self._solve_NX(other)
+
+        return (ret, self._get_logdet()) if logdet else ret
+
+
 class ShermanMorrison(object):
     """Custom container class for Sherman-morrison array inversion."""
 
@@ -403,10 +492,11 @@ class ShermanMorrison(object):
 
         Nx = x / self._nvec
         for slc, jv in zip(self._slices, self._jvec):
-            rblock = x[slc]
-            niblock = 1 / self._nvec[slc]
-            beta = 1.0 / (np.einsum('i->', niblock) + 1.0/jv)
-            Nx[slc] -= beta * np.dot(niblock, rblock) * niblock
+            if slc.stop - slc.start > 1:
+                rblock = x[slc]
+                niblock = 1 / self._nvec[slc]
+                beta = 1.0 / (np.einsum('i->', niblock) + 1.0/jv)
+                Nx[slc] -= beta * np.dot(niblock, rblock) * niblock
         return Nx
 
     def _solve_1D1(self, x, y):
@@ -417,11 +507,12 @@ class ShermanMorrison(object):
         Nx = x / self._nvec
         yNx = np.dot(y, Nx)
         for slc, jv in zip(self._slices, self._jvec):
-            xblock = x[slc]
-            yblock = y[slc]
-            niblock = 1 / self._nvec[slc]
-            beta = 1.0 / (np.einsum('i->', niblock)+1.0/jv)
-            yNx -= beta * np.dot(niblock, xblock) * np.dot(niblock, yblock)
+            if slc.stop - slc.start > 1:
+                xblock = x[slc]
+                yblock = y[slc]
+                niblock = 1 / self._nvec[slc]
+                beta = 1.0 / (np.einsum('i->', niblock)+1.0/jv)
+                yNx -= beta * np.dot(niblock, xblock) * np.dot(niblock, yblock)
         return yNx
 
     def _solve_2D2(self, X, Z):
@@ -431,13 +522,14 @@ class ShermanMorrison(object):
 
         ZNX = np.dot(Z.T / self._nvec, X)
         for slc, jv in zip(self._slices, self._jvec):
-            Zblock = Z[slc, :]
-            Xblock = X[slc, :]
-            niblock = 1 / self._nvec[slc]
-            beta = 1.0 / (np.einsum('i->', niblock)+1.0/jv)
-            zn = np.dot(niblock, Zblock)
-            xn = np.dot(niblock, Xblock)
-            ZNX -= beta * np.outer(zn.T, xn)
+            if slc.stop - slc.start > 1:
+                Zblock = Z[slc, :]
+                Xblock = X[slc, :]
+                niblock = 1 / self._nvec[slc]
+                beta = 1.0 / (np.einsum('i->', niblock)+1.0/jv)
+                zn = np.dot(niblock, Zblock)
+                xn = np.dot(niblock, Xblock)
+                ZNX -= beta * np.outer(zn.T, xn)
         return ZNX
 
     def _get_logdet(self):
@@ -446,9 +538,10 @@ class ShermanMorrison(object):
         """
         logdet = np.einsum('i->', np.log(self._nvec))
         for slc, jv in zip(self._slices, self._jvec):
-            niblock = 1 / self._nvec[slc]
-            beta = 1.0 / (np.einsum('i->', niblock)+1.0/jv)
-            logdet += np.log(jv) - np.log(beta)
+            if slc.stop - slc.start > 1:
+                niblock = 1 / self._nvec[slc]
+                beta = 1.0 / (np.einsum('i->', niblock)+1.0/jv)
+                logdet += np.log(jv) - np.log(beta)
         return logdet
 
     def solve(self, other, left_array=None, logdet=False):

--- a/enterprise/signals/utils.py
+++ b/enterprise/signals/utils.py
@@ -611,7 +611,7 @@ def fplus_fcross(ptheta, pphi, gwtheta, gwphi):
     return fplus, fcross
 
 
-def create_quantization_matrix(times, dt=1):
+def create_quantization_matrix(times, dt=1, nmin=2):
     """Create quantization matrix mapping TOAs to observing epochs."""
     isort = np.argsort(times)
 
@@ -626,13 +626,31 @@ def create_quantization_matrix(times, dt=1):
             bucket_ind.append([i])
 
     # find only epochs with more than 1 TOA
-    bucket_ind2 = [ind for ind in bucket_ind if len(ind) > 2]
+    bucket_ind2 = [ind for ind in bucket_ind if len(ind) >= nmin]
 
     U = np.zeros((len(times),len(bucket_ind2)),'d')
     for i,l in enumerate(bucket_ind2):
         U[l,i] = 1
 
     return U
+
+
+def quant2ind(U):
+    """
+    Use quantization matrix to return slices of non-zero elements.
+
+    :param U: quantization matrix
+
+    :return: list of `slice`s for non-zero elements of U
+
+    .. note:: This function assumes that the pulsar TOAs were sorted by time.
+
+    """
+    inds = []
+    for cc, col in enumerate(U.T):
+        epinds = np.flatnonzero(col)
+        inds.append(slice(epinds[0], epinds[-1]+1))
+    return inds
 
 
 def powerlaw(f, log10_A=-16, gamma=5):

--- a/enterprise/signals/utils.py
+++ b/enterprise/signals/utils.py
@@ -649,6 +649,8 @@ def quant2ind(U):
     inds = []
     for cc, col in enumerate(U.T):
         epinds = np.flatnonzero(col)
+        if epinds[-1] - epinds[0] + 1 != len(epinds):
+            raise ValueError('ERROR: TOAs not sorted properly!')
         inds.append(slice(epinds[0], epinds[-1]+1))
     return inds
 

--- a/enterprise/signals/white_signals.py
+++ b/enterprise/signals/white_signals.py
@@ -64,7 +64,62 @@ def EquadNoise(log10_equad=parameter.Uniform(-10,-5),
 def EcorrKernelNoise(log10_ecorr=parameter.Uniform(-10, -5),
                      selection=Selection(selections.no_selection),
                      method='sherman-morrison'):
-    """Class factory for ECORR type noise using."""
+    """Class factory for ECORR type noise.
+
+    :param log10_ecorr: ``Parameter`` type for log10 or ecorr parameter.
+    :param selection:
+        ``Selection`` object specifying masks for backends, time segments, etc.
+    :param method: Method for computing noise covariance matrix.
+        Options include `sherman-morrison`, `sparse`, and `block`
+
+    :return: ``EcorrKernelNoise`` class.
+
+    ECORR is a noise signal that is used for data with multi-channel TOAs
+    that are nearly simultaneous in time. It is a white noise signal that
+    is uncorrelated epoch to epoch but completely correlated for TOAs in a
+    given observing epoch.
+
+    Mathematically, ECORR can be described by the covariance matrix
+
+    .. math:: C_{ecorr} = UJU^T,
+
+    where :math:`U` is a quantization matrix that maps TOAs to
+    their respective epochs and :math:`J` is a diagonal matrix of the
+    variance of the epoch to epoch fluctuations.
+
+    For this implementation we use this covariance matrix as part of the
+    white noise covariance matrix :math:`N`. It can be seen from above that
+    this covariance is block diagonal, thus allowing us to exploit special
+    methods to make matrix manipulations easier.
+
+    In this signal implementation we offer three methods of performing these
+    matrix operations:
+
+    sherman-morrison
+        Uses the `Sherman-Morrison`_ forumla to compute the matrix
+        inverse and other matrix operations. **Note:** This method can only
+        be used for covariances that can be constructed by the outer product
+        of two vectors, :math:`uv^T`.
+
+    sparse
+        Uses `Scipy Sparse`_ matrices to construct the block diagonal
+        covariance matrix and perform matrix operations.
+
+    block
+        Uses a custom scheme that uses the individual blocks from the block
+        diagonal matrix to perform fast matrix inverse and other solve
+        operations.
+
+    .. note:: The sherman-morrison method is the fastest, followed by the block
+        and then sparse methods, however; the block and sparse methods are more
+        general and should be used if sub-classing this signal for more complicated
+        blocks.
+
+    .. _Sherman-Morrison: https://en.wikipedia.org/wiki/Sherman-Morrison_formula
+    .. _Scipy Sparse: https://docs.scipy.org/doc/scipy-0.18.1/reference/sparse.html
+    .. # noqa E501
+
+    """
 
     if method not in ['sherman-morrison', 'block', 'sparse']:
         msg = 'EcorrKernelNoise does not support method: {}'.format(method)

--- a/enterprise/signals/white_signals.py
+++ b/enterprise/signals/white_signals.py
@@ -141,7 +141,7 @@ def EcorrKernelNoiseBlock(log10_ecorr=parameter.Uniform(-10, -5),
                           selection=Selection(selections.no_selection)):
     """Class factory for ECORR type noise using Block method."""
 
-    BaseClass = EcorrKernelNoiseSM(log10_ecorr=log10_ecorr, selection=selection)
+    BaseClass = EcorrKernelNoiseSM(log10_ecorr=log10_ecorr,selection=selection)
 
     class EcorrKernelNoiseBlock(BaseClass):
 

--- a/enterprise/signals/white_signals.py
+++ b/enterprise/signals/white_signals.py
@@ -61,11 +61,11 @@ def EquadNoise(log10_equad=parameter.Uniform(-10,-5),
     return EquadNoise
 
 
-def EcorrKernelNoise(log10_ecorr=parameter.Uniform(-10, -5),
-                     selection=Selection(selections.no_selection)):
+def EcorrKernelNoiseSparse(log10_ecorr=parameter.Uniform(-10, -5),
+                           selection=Selection(selections.no_selection)):
     """Class factory for ECORR type noise using Sparse method."""
 
-    class EcorrKernelNoise(base.Signal):
+    class EcorrKernelNoiseSparse(base.Signal):
         signal_type = 'white noise'
         signal_name = 'ecorr_sparse'
 
@@ -110,14 +110,15 @@ def EcorrKernelNoise(log10_ecorr=parameter.Uniform(-10, -5),
                         self._Ns[slc, slc] = 10**(2*self.get(p, params))
             return self._Ns
 
-    return EcorrKernelNoise
+    return EcorrKernelNoiseSparse
 
 
 def EcorrKernelNoiseSM(log10_ecorr=parameter.Uniform(-10, -5),
                        selection=Selection(selections.no_selection)):
     """Class factory for ECORR type noise using Sherman-Morrison method."""
 
-    BaseClass = EcorrKernelNoise(log10_ecorr=log10_ecorr, selection=selection)
+    BaseClass = EcorrKernelNoiseSparse(log10_ecorr=log10_ecorr,
+                                       selection=selection)
 
     class EcorrKernelNoiseSM(BaseClass):
         signal_type = 'white noise'

--- a/enterprise/signals/white_signals.py
+++ b/enterprise/signals/white_signals.py
@@ -64,7 +64,62 @@ def EquadNoise(log10_equad=parameter.Uniform(-10,-5),
 def EcorrKernelNoise(log10_ecorr=parameter.Uniform(-10, -5),
                      selection=Selection(selections.no_selection),
                      method='sherman-morrison'):
-    """Class factory for ECORR type noise."""
+    r"""Class factory for ECORR type noise.
+
+    :param log10_ecorr: ``Parameter`` type for log10 or ecorr parameter.
+    :param selection:
+        ``Selection`` object specifying masks for backends, time segments, etc.
+    :param method: Method for computing noise covariance matrix.
+        Options include `sherman-morrison`, `sparse`, and `block`
+
+    :return: ``EcorrKernelNoise`` class.
+
+    ECORR is a noise signal that is used for data with multi-channel TOAs
+    that are nearly simultaneous in time. It is a white noise signal that
+    is uncorrelated epoch to epoch but completely correlated for TOAs in a
+    given observing epoch.
+
+    Mathematically, ECORR can be described by the covariance matrix
+
+    .. math:: C_{ecorr} = UJU^T,
+
+    where :math:`U` is a quantization matrix that maps TOAs to
+    their respective epochs and :math:`J` is a diagonal matrix of the
+    variance of the epoch to epoch fluctuations.
+
+    For this implementation we use this covariance matrix as part of the
+    white noise covariance matrix :math:`N`. It can be seen from above that
+    this covariance is block diagonal, thus allowing us to exploit special
+    methods to make matrix manipulations easier.
+
+    In this signal implementation we offer three methods of performing these
+    matrix operations:
+
+    sherman-morrison
+        Uses the `Sherman-Morrison`_ forumla to compute the matrix
+        inverse and other matrix operations. **Note:** This method can only
+        be used for covariances that can be constructed by the outer product
+        of two vectors, :math:`uv^T`.
+
+    sparse
+        Uses `Scipy Sparse`_ matrices to construct the block diagonal
+        covariance matrix and perform matrix operations.
+
+    block
+        Uses a custom scheme that uses the individual blocks from the block
+        diagonal matrix to perform fast matrix inverse and other solve
+        operations.
+
+    .. note:: The sherman-morrison method is the fastest, followed by the block
+        and then sparse methods, however; the block and sparse methods are more
+        general and should be used if sub-classing this signal for more complicated
+        blocks.
+
+    .. _Sherman-Morrison: https://en.wikipedia.org/wiki/Sherman-Morrison_formula
+    .. _Scipy Sparse: https://docs.scipy.org/doc/scipy-0.18.1/reference/sparse.html
+    .. # noqa E501
+
+    """
 
     if method not in ['sherman-morrison', 'block', 'sparse']:
         msg = 'EcorrKernelNoise does not support method: {}'.format(method)

--- a/enterprise/signals/white_signals.py
+++ b/enterprise/signals/white_signals.py
@@ -7,9 +7,11 @@ from __future__ import (absolute_import, division,
                         print_function, unicode_literals)
 
 import numpy as np
+import scipy.sparse
 
 from enterprise.signals import parameter
 import enterprise.signals.signal_base as base
+from enterprise.signals import utils
 from enterprise.signals import selections
 from enterprise.signals.selections import Selection
 
@@ -57,3 +59,80 @@ def EquadNoise(log10_equad=parameter.Uniform(-10,-5),
             return ret
 
     return EquadNoise
+
+
+def EcorrKernelNoise(log10_ecorr=parameter.Uniform(-10, -5),
+                     selection=Selection(selections.no_selection)):
+    """Class factory for ECORR type noise using Sparse method."""
+
+    class EcorrKernelNoise(base.Signal):
+        signal_type = 'white noise'
+        signal_name = 'ecorr_sparse'
+
+        def __init__(self, psr):
+
+            sel = selection(psr)
+            self._params, self._masks = sel('log10_ecorr', log10_ecorr)
+            Umats = {}
+            for key in sorted(self._masks.keys()):
+                mask = self._masks[key]
+                Umats.update({key: utils.create_quantization_matrix(
+                    psr.toas[mask], nmin=1)})
+            nepoch = np.sum(U.shape[1] for U in Umats.values())
+            self._F = np.zeros((len(psr.toas), nepoch))
+            netot = 0
+            self._slices = {}
+            for key in sorted(self._masks.keys()):
+                mask = self._masks[key]
+                Umat = Umats[key]
+                nn = Umat.shape[1]
+                self._F[mask, netot:nn+netot] = Umat
+                self._slices.update({key: utils.quant2ind(
+                    self._F[:,netot:nn+netot])})
+                netot += nn
+
+            # initialize sparse matrix
+            self._setup(psr)
+
+        def _setup(self, psr):
+            Ns = scipy.sparse.csc_matrix((len(psr.toas), len(psr.toas)))
+            for key, slices in self._slices.items():
+                for slc in slices:
+                    if slc.stop - slc.start > 1:
+                        Ns[slc, slc] = 1.0
+            self._Ns = base.csc_matrix_alt(Ns)
+
+        def get_ndiag(self, params):
+            for p in self._params:
+                for slc in self._slices[p]:
+                    if slc.stop - slc.start > 1:
+                        self._Ns[slc, slc] = 10**(2*self.get(p, params))
+            return self._Ns
+
+    return EcorrKernelNoise
+
+
+def EcorrKernelNoiseSM(log10_ecorr=parameter.Uniform(-10, -5),
+                       selection=Selection(selections.no_selection)):
+    """Class factory for ECORR type noise using Sherman-Morrison method."""
+
+    BaseClass = EcorrKernelNoise(log10_ecorr=log10_ecorr, selection=selection)
+
+    class EcorrKernelNoiseSM(BaseClass):
+
+        def __init__(self, psr):
+            super(EcorrKernelNoiseSM, self).__init__(psr)
+
+        def _setup(self, psr):
+            pass
+
+        def get_ndiag(self, params):
+            slices = sum([self._slices[key] for key in
+                          sorted(self._slices.keys())], [])
+            jvec = np.concatenate(
+                [np.ones(len(self._slices[key]))*10**(2*self.get(key, params))
+                 for key in sorted(self._slices.keys())])
+
+            return base.ShermanMorrison(jvec, slices)
+
+    return EcorrKernelNoiseSM

--- a/enterprise/signals/white_signals.py
+++ b/enterprise/signals/white_signals.py
@@ -122,9 +122,6 @@ def EcorrKernelNoiseSM(log10_ecorr=parameter.Uniform(-10, -5),
 
     class EcorrKernelNoiseSM(BaseClass):
 
-        def __init__(self, psr):
-            super(EcorrKernelNoiseSM, self).__init__(psr)
-
         def _setup(self, psr):
             pass
 
@@ -144,15 +141,9 @@ def EcorrKernelNoiseBlock(log10_ecorr=parameter.Uniform(-10, -5),
                           selection=Selection(selections.no_selection)):
     """Class factory for ECORR type noise using Block method."""
 
-    BaseClass = EcorrKernelNoise(log10_ecorr=log10_ecorr, selection=selection)
+    BaseClass = EcorrKernelNoiseSM(log10_ecorr=log10_ecorr, selection=selection)
 
     class EcorrKernelNoiseBlock(BaseClass):
-
-        def __init__(self, psr):
-            super(EcorrKernelNoiseBlock, self).__init__(psr)
-
-        def _setup(self, psr):
-            pass
 
         def get_ndiag(self, params):
             slices = sum([self._slices[key] for key in

--- a/enterprise/signals/white_signals.py
+++ b/enterprise/signals/white_signals.py
@@ -79,7 +79,7 @@ def EcorrKernelNoise(log10_ecorr=parameter.Uniform(-10, -5),
             for key in sorted(self._masks.keys()):
                 mask = self._masks[key]
                 Umats.update({key: utils.create_quantization_matrix(
-                    psr.toas[mask], nmin=1)})
+                    psr.toas[mask])})
             nepoch = np.sum(U.shape[1] for U in Umats.values())
             self._F = np.zeros((len(psr.toas), nepoch))
             netot = 0
@@ -100,15 +100,13 @@ def EcorrKernelNoise(log10_ecorr=parameter.Uniform(-10, -5),
             Ns = scipy.sparse.csc_matrix((len(psr.toas), len(psr.toas)))
             for key, slices in self._slices.items():
                 for slc in slices:
-                    if slc.stop - slc.start > 1:
-                        Ns[slc, slc] = 1.0
+                    Ns[slc, slc] = 1.0
             self._Ns = base.csc_matrix_alt(Ns)
 
         def get_ndiag(self, params):
             for p in self._params:
                 for slc in self._slices[p]:
-                    if slc.stop - slc.start > 1:
-                        self._Ns[slc, slc] = 10**(2*self.get(p, params))
+                    self._Ns[slc, slc] = 10**(2*self.get(p, params))
             return self._Ns
 
     return EcorrKernelNoise

--- a/enterprise/signals/white_signals.py
+++ b/enterprise/signals/white_signals.py
@@ -79,14 +79,6 @@ def EcorrKernelNoise(log10_ecorr=parameter.Uniform(-10, -5),
     is uncorrelated epoch to epoch but completely correlated for TOAs in a
     given observing epoch.
 
-    Mathematically, ECORR can be described by the covariance matrix
-
-    .. math:: C_{ecorr} = UJU^T,
-
-    where :math:`U` is a quantization matrix that maps TOAs to
-    their respective epochs and :math:`J` is a diagonal matrix of the
-    variance of the epoch to epoch fluctuations.
-
     For this implementation we use this covariance matrix as part of the
     white noise covariance matrix :math:`N`. It can be seen from above that
     this covariance is block diagonal, thus allowing us to exploit special
@@ -112,8 +104,8 @@ def EcorrKernelNoise(log10_ecorr=parameter.Uniform(-10, -5),
 
     .. note:: The sherman-morrison method is the fastest, followed by the block
         and then sparse methods, however; the block and sparse methods are more
-        general and should be used if sub-classing this signal for more complicated
-        blocks.
+        general and should be used if sub-classing this signal for more
+        complicated blocks.
 
     .. _Sherman-Morrison: https://en.wikipedia.org/wiki/Sherman-Morrison_formula
     .. _Scipy Sparse: https://docs.scipy.org/doc/scipy-0.18.1/reference/sparse.html

--- a/enterprise/signals/white_signals.py
+++ b/enterprise/signals/white_signals.py
@@ -71,6 +71,8 @@ def EcorrKernelNoise(log10_ecorr=parameter.Uniform(-10, -5),
 
         def __init__(self, psr):
 
+            # TODO: Add check for proper TOA sorting
+
             sel = selection(psr)
             self._params, self._masks = sel('log10_ecorr', log10_ecorr)
             Umats = {}

--- a/enterprise/signals/white_signals.py
+++ b/enterprise/signals/white_signals.py
@@ -64,62 +64,7 @@ def EquadNoise(log10_equad=parameter.Uniform(-10,-5),
 def EcorrKernelNoise(log10_ecorr=parameter.Uniform(-10, -5),
                      selection=Selection(selections.no_selection),
                      method='sherman-morrison'):
-    """Class factory for ECORR type noise.
-
-    :param log10_ecorr: ``Parameter`` type for log10 or ecorr parameter.
-    :param selection:
-        ``Selection`` object specifying masks for backends, time segments, etc.
-    :param method: Method for computing noise covariance matrix.
-        Options include `sherman-morrison`, `sparse`, and `block`
-
-    :return: ``EcorrKernelNoise`` class.
-
-    ECORR is a noise signal that is used for data with multi-channel TOAs
-    that are nearly simultaneous in time. It is a white noise signal that
-    is uncorrelated epoch to epoch but completely correlated for TOAs in a
-    given observing epoch.
-
-    Mathematically, ECORR can be described by the covariance matrix
-
-    .. math:: C_{ecorr} = UJU^T,
-
-    where :math:`U` is a quantization matrix that maps TOAs to
-    their respective epochs and :math:`J` is a diagonal matrix of the
-    variance of the epoch to epoch fluctuations.
-
-    For this implementation we use this covariance matrix as part of the
-    white noise covariance matrix :math:`N`. It can be seen from above that
-    this covariance is block diagonal, thus allowing us to exploit special
-    methods to make matrix manipulations easier.
-
-    In this signal implementation we offer three methods of performing these
-    matrix operations:
-
-    sherman-morrison
-        Uses the `Sherman-Morrison`_ forumla to compute the matrix
-        inverse and other matrix operations. **Note:** This method can only
-        be used for covariances that can be constructed by the outer product
-        of two vectors, :math:`uv^T`.
-
-    sparse
-        Uses `Scipy Sparse`_ matrices to construct the block diagonal
-        covariance matrix and perform matrix operations.
-
-    block
-        Uses a custom scheme that uses the individual blocks from the block
-        diagonal matrix to perform fast matrix inverse and other solve
-        operations.
-
-    .. note:: The sherman-morrison method is the fastest, followed by the block
-        and then sparse methods, however; the block and sparse methods are more
-        general and should be used if sub-classing this signal for more complicated
-        blocks.
-
-    .. _Sherman-Morrison: https://en.wikipedia.org/wiki/Sherman-Morrison_formula
-    .. _Scipy Sparse: https://docs.scipy.org/doc/scipy-0.18.1/reference/sparse.html
-    .. # noqa E501
-
-    """
+    """Class factory for ECORR type noise."""
 
     if method not in ['sherman-morrison', 'block', 'sparse']:
         msg = 'EcorrKernelNoise does not support method: {}'.format(method)

--- a/tests/test_pulsar.py
+++ b/tests/test_pulsar.py
@@ -56,11 +56,11 @@ class TestPulsar(unittest.TestCase):
         msg = 'Flags shape incorrect'
         assert self.psr.flags['f'].shape == (5634,), msg
 
-    #def test_backend_flags(self):
-    #    """Check backend_flags shape."""
-#
-    #    msg = 'Backend Flags shape incorrect'
-    #    assert self.psr.backend_flags.shape == (5634,), msg
+    def test_backend_flags(self):
+        """Check backend_flags shape."""
+
+        msg = 'Backend Flags shape incorrect'
+        assert self.psr.backend_flags.shape == (5634,), msg
 
     def test_sky(self):
         """Check Sky location."""

--- a/tests/test_pulsar.py
+++ b/tests/test_pulsar.py
@@ -24,7 +24,8 @@ class TestPulsar(unittest.TestCase):
 
         # initialize Pulsar class
         self.psr = Pulsar(datadir + '/B1855+09_NANOGrav_11yv0.gls.par',
-                          datadir + '/B1855+09_NANOGrav_11yv0.tim')
+                          datadir + '/B1855+09_NANOGrav_11yv0.tim',
+                          drop_t2pulsar=False)
 
     def test_residuals(self):
         """Check Residual shape."""

--- a/tests/test_pulsar.py
+++ b/tests/test_pulsar.py
@@ -24,8 +24,7 @@ class TestPulsar(unittest.TestCase):
 
         # initialize Pulsar class
         self.psr = Pulsar(datadir + '/B1855+09_NANOGrav_11yv0.gls.par',
-                          datadir + '/B1855+09_NANOGrav_11yv0.tim',
-                          drop_t2pulsar=False)
+                          datadir + '/B1855+09_NANOGrav_11yv0.tim')
 
     def test_residuals(self):
         """Check Residual shape."""

--- a/tests/test_pulsar.py
+++ b/tests/test_pulsar.py
@@ -56,11 +56,11 @@ class TestPulsar(unittest.TestCase):
         msg = 'Flags shape incorrect'
         assert self.psr.flags['f'].shape == (5634,), msg
 
-    def test_backend_flags(self):
-        """Check backend_flags shape."""
-
-        msg = 'Backend Flags shape incorrect'
-        assert self.psr.backend_flags.shape == (5634,), msg
+    #def test_backend_flags(self):
+    #    """Check backend_flags shape."""
+#
+    #    msg = 'Backend Flags shape incorrect'
+    #    assert self.psr.backend_flags.shape == (5634,), msg
 
     def test_sky(self):
         """Check Sky location."""

--- a/tests/test_white_signals.py
+++ b/tests/test_white_signals.py
@@ -313,4 +313,4 @@ class TestWhiteSignals(unittest.TestCase):
 
     def test_ecorr_block(self):
         """Test of block matrix ecorr signal and solve methods."""
-        self._ecorr_test(method='sherman-morrison')
+        self._ecorr_test(method='block')

--- a/tests/test_white_signals.py
+++ b/tests/test_white_signals.py
@@ -225,6 +225,9 @@ class TestWhiteSignals(unittest.TestCase):
             ec = ws.EcorrKernelNoise(log10_ecorr=ecorr, selection=selection)
         elif method == 'sherman-morrison':
             ec = ws.EcorrKernelNoiseSM(log10_ecorr=ecorr, selection=selection)
+        elif method == 'block':
+            ec = ws.EcorrKernelNoiseBlock(log10_ecorr=ecorr,
+                                          selection=selection)
         tm = gp.TimingModel()
         s = ef + ec + tm
         m = s(self.psr)
@@ -306,4 +309,8 @@ class TestWhiteSignals(unittest.TestCase):
 
     def test_ecorr_sherman_morrison(self):
         """Test of sherman-morrison ecorr signal and solve methods."""
+        self._ecorr_test(method='sherman-morrison')
+
+    def test_ecorr_block(self):
+        """Test of block matrix ecorr signal and solve methods."""
         self._ecorr_test(method='sherman-morrison')

--- a/tests/test_white_signals.py
+++ b/tests/test_white_signals.py
@@ -221,15 +221,8 @@ class TestWhiteSignals(unittest.TestCase):
         efac = parameter.Uniform(0.1, 5)
         ecorr = parameter.Uniform(-10, -5)
         ef = ws.MeasurementNoise(efac=efac, selection=selection)
-        if method == 'sparse':
-            ec = ws.EcorrKernelNoiseSparse(log10_ecorr=ecorr,
-                                           selection=selection)
-        elif method == 'sherman-morrison':
-            ec = ws.EcorrKernelNoiseSM(log10_ecorr=ecorr,
-                                       selection=selection)
-        elif method == 'block':
-            ec = ws.EcorrKernelNoiseBlock(log10_ecorr=ecorr,
-                                          selection=selection)
+        ec = ws.EcorrKernelNoise(log10_ecorr=ecorr, selection=selection,
+                                 method=method)
         tm = gp.TimingModel()
         s = ef + ec + tm
         m = s(self.psr)

--- a/tests/test_white_signals.py
+++ b/tests/test_white_signals.py
@@ -11,6 +11,7 @@ Tests for white signal modules.
 
 import unittest
 import numpy as np
+import scipy.linalg as sl
 
 from tests.enterprise_test_data import datadir
 from enterprise.pulsar import Pulsar
@@ -18,6 +19,8 @@ from enterprise.signals import parameter
 from enterprise.signals import selections
 from enterprise.signals.selections import Selection
 import enterprise.signals.white_signals as ws
+import enterprise.signals.gp_signals as gp
+from enterprise.signals import utils
 
 
 class TestWhiteSignals(unittest.TestCase):
@@ -176,6 +179,131 @@ class TestWhiteSignals(unittest.TestCase):
             nvec0[ind] = efacs[ct]**2 * self.psr.toaerrs[ind]**2
             nvec0[ind] += 10**(2*equads[ct]) * np.ones(np.sum(ind))
 
+        logdet = np.sum(np.log(nvec0))
+
         # test
         msg = 'EFAC/EQUAD covariance incorrect.'
         assert np.all(m.get_ndiag(params) == nvec0), msg
+
+        msg = 'EFAC/EQUAD logdet incorrect.'
+        N = m.get_ndiag(params)
+        assert np.allclose(N.solve(self.psr.residuals, logdet=True)[1],
+                           logdet, rtol=1e-10), msg
+
+        msg = 'EFAC/EQUAD D1 solve incorrect.'
+        assert np.allclose(N.solve(self.psr.residuals),
+                           self.psr.residuals/nvec0,
+                           rtol=1e-10), msg
+
+        msg = 'EFAC/EQUAD 1D1 solve incorrect.'
+        assert np.allclose(
+            N.solve(self.psr.residuals, left_array=self.psr.residuals),
+            np.dot(self.psr.residuals/nvec0, self.psr.residuals),
+            rtol=1e-10), msg
+
+        msg = 'EFAC/EQUAD 2D1 solve incorrect.'
+        T = self.psr.Mmat
+        assert np.allclose(
+            N.solve(self.psr.residuals, left_array=T),
+            np.dot(T.T, self.psr.residuals/nvec0),
+            rtol=1e-10), msg
+
+        msg = 'EFAC/EQUAD 2D2 solve incorrect.'
+        assert np.allclose(
+            N.solve(T, left_array=T),
+            np.dot(T.T, T/nvec0[:,None]),
+            rtol=1e-10), msg
+
+    def _ecorr_test(self, method='sparse'):
+        """Test of sparse/sherman-morrison ecorr signal and solve methods."""
+        selection = Selection(selections.by_backend)
+
+        efac = parameter.Uniform(0.1, 5)
+        ecorr = parameter.Uniform(-10, -5)
+        ef = ws.MeasurementNoise(efac=efac, selection=selection)
+        if method == 'sparse':
+            ec = ws.EcorrKernelNoise(log10_ecorr=ecorr, selection=selection)
+        elif method == 'sherman-morrison':
+            ec = ws.EcorrKernelNoiseSM(log10_ecorr=ecorr, selection=selection)
+        tm = gp.TimingModel()
+        s = ef + ec + tm
+        m = s(self.psr)
+
+        # set parameters
+        efacs = [1.3, 1.4, 1.5, 1.6]
+        ecorrs = [-6.1, -6.2, -6.3, -6.4]
+        params = {'B1855+09_efac_430_ASP': efacs[0],
+                  'B1855+09_efac_430_PUPPI': efacs[1],
+                  'B1855+09_efac_L-wide_ASP': efacs[2],
+                  'B1855+09_efac_L-wide_PUPPI': efacs[3],
+                  'B1855+09_log10_ecorr_430_ASP': ecorrs[0],
+                  'B1855+09_log10_ecorr_430_PUPPI': ecorrs[1],
+                  'B1855+09_log10_ecorr_L-wide_ASP': ecorrs[2],
+                  'B1855+09_log10_ecorr_L-wide_PUPPI': ecorrs[3]}
+
+        # get EFAC Nvec
+        flags = ['430_ASP', '430_PUPPI', 'L-wide_ASP', 'L-wide_PUPPI']
+        nvec0 = np.zeros_like(self.psr.toas)
+        for ct, flag in enumerate(np.unique(flags)):
+            ind = flag == self.psr.backend_flags
+            nvec0[ind] = efacs[ct]**2 * self.psr.toaerrs[ind]**2
+
+        # get the basis
+        bflags = self.psr.backend_flags
+        Umats = []
+        for flag in np.unique(bflags):
+            mask = bflags == flag
+            Umats.append(utils.create_quantization_matrix(self.psr.toas[mask]))
+        nepoch = sum(U.shape[1] for U in Umats)
+        U = np.zeros((len(self.psr.toas), nepoch))
+        jvec = np.zeros(nepoch)
+        netot = 0
+        for ct, flag in enumerate(np.unique(bflags)):
+            mask = bflags == flag
+            nn = Umats[ct].shape[1]
+            U[mask, netot:nn+netot] = Umats[ct]
+            jvec[netot:nn+netot] = 10**(2*ecorrs[ct])
+            netot += nn
+
+        # get covariance matrix
+        cov = np.diag(nvec0) + np.dot(U*jvec[None, :], U.T)
+        cf = sl.cho_factor(cov)
+        logdet = np.sum(2*np.log(np.diag(cf[0])))
+
+        # test
+        msg = 'EFAC/ECORR {} logdet incorrect.'.format(method)
+        N = m.get_ndiag(params)
+        assert np.allclose(N.solve(self.psr.residuals, logdet=True)[1],
+                           logdet, rtol=1e-10), msg
+
+        msg = 'EFAC/ECORR {} D1 solve incorrect.'.format(method)
+        assert np.allclose(N.solve(self.psr.residuals),
+                           sl.cho_solve(cf, self.psr.residuals),
+                           rtol=1e-10), msg
+
+        msg = 'EFAC/ECORR {} 1D1 solve incorrect.'.format(method)
+        assert np.allclose(
+            N.solve(self.psr.residuals, left_array=self.psr.residuals),
+            np.dot(self.psr.residuals, sl.cho_solve(cf, self.psr.residuals)),
+            rtol=1e-10), msg
+
+        msg = 'EFAC/ECORR {} 2D1 solve incorrect.'.format(method)
+        T = m.get_basis()
+        assert np.allclose(
+            N.solve(self.psr.residuals, left_array=T),
+            np.dot(T.T, sl.cho_solve(cf, self.psr.residuals)),
+            rtol=1e-10), msg
+
+        msg = 'EFAC/ECORR {} 2D2 solve incorrect.'.format(method)
+        assert np.allclose(
+            N.solve(T, left_array=T),
+            np.dot(T.T, sl.cho_solve(cf, T)),
+            rtol=1e-10), msg
+
+    def test_ecorr_sparse(self):
+        """Test of sparse ecorr signal and solve methods."""
+        self._ecorr_test(method='sparse')
+
+    def test_ecorr_sherman_morrison(self):
+        """Test of sherman-morrison ecorr signal and solve methods."""
+        self._ecorr_test(method='sherman-morrison')

--- a/tests/test_white_signals.py
+++ b/tests/test_white_signals.py
@@ -222,9 +222,11 @@ class TestWhiteSignals(unittest.TestCase):
         ecorr = parameter.Uniform(-10, -5)
         ef = ws.MeasurementNoise(efac=efac, selection=selection)
         if method == 'sparse':
-            ec = ws.EcorrKernelNoise(log10_ecorr=ecorr, selection=selection)
+            ec = ws.EcorrKernelNoiseSparse(log10_ecorr=ecorr,
+                                           selection=selection)
         elif method == 'sherman-morrison':
-            ec = ws.EcorrKernelNoiseSM(log10_ecorr=ecorr, selection=selection)
+            ec = ws.EcorrKernelNoiseSM(log10_ecorr=ecorr,
+                                       selection=selection)
         elif method == 'block':
             ec = ws.EcorrKernelNoiseBlock(log10_ecorr=ecorr,
                                           selection=selection)


### PR DESCRIPTION
I'm starting this PR, again, so we can take a look at how things are progressing. It still needs tests and some cleanup related to Issue #90. Some of the new code is pretty cool, IMHO. To deal with ECORR in the `N` matrix we need to make it play nice with the standard `N` "vector" (i.e. the diagonal part of a diagonal matrix) that we use for EFAC, and EQUAD. In order to do this I've created three special data types: `ndarray_alt`, `csc_matrix_alt`, and `ShermanMorrison`. They all have their own `__add__` methods so that they know how to add to one another (note that `csc_matrix_alt` cannot be added to `ShermanMorrison` at the moment but I don't know if you would ever want to do that anyway). They also have their own `solve` methods that have the same API for all so that the `Likelihood` doesn't need to know which kind of `N` you are using.

Here is how it works: the EFAC and EQUAD signals return `ndarray_alt` arrays (basically `numpy` arrays with special `__add__` and `solve` methods), ECORR (sparse) signals return `csc_matrix_alt` arrays (which, again, are a special type of `spicy.sparse.csc` matrix with `__add__` and `solve` methods), and ECORR (sherman-morrison) signals return a `ShermanMorrison` array. This way when computing the total `N` in `SignalCollection` using the `sum` function we return the correct type. For example `ndarray_alt` + `csc_matrix_alt` returns a `csc_matrix_alt` type array where we can then call `solve` in the likelihood. The same is true for `ndarray_alt` + `ShermanMorrison` where it returns a `ShermanMorrison` type array. I have done tests and all of this works smoothly but there are still a few more checks to do.

Here is how to use the solve method (for any of the three types mentioned above):
To solve Y^T N^{-1} X, where X and Y can be either vectors or matrices of the correct shape you can do `N.solve(X, left_array=Y)`. 

Lastly, in terms of the ECORR signal factories themselves I have defined `EcorrKernelNoise` which implements the sparse matrix version and have sub-classed that to create `EcorrKernelNoiseSM` which implements the Sherman-Morrison version. I would still like to clean these up a bit and make them easier to subclass but they are working now.

Timings (model `m` is EFAC + ECORR(sherman morrison) + timing model, model `m2` is the same but with ECORR (sparse)) for J1909-3744:
```python
T = m.get_basis()
N1 = m.get_ndiag(params)
N2 = m2.get_ndiag(params)
%timeit -n5 m.get_ndiag(params)
%timeit -n5 m2.get_ndiag(params)
%timeit -n5 N1.solve(psr.residuals, left_array=T, logdet=True)
%timeit -n5 N2.solve(psr.residuals, left_array=T, logdet=True)
%timeit -n5 N1.solve(T, left_array=T)
%timeit -n5 N2.solve(T, left_array=T)
```
returns :
```python
5 loops, best of 3: 159 µs per loop
5 loops, best of 3: 99.7 ms per loop
5 loops, best of 3: 10.5 ms per loop
5 loops, best of 3: 29.9 ms per loop
5 loops, best of 3: 86 ms per loop
5 loops, best of 3: 96.6 ms per loop
```
So the solve method is fairly similar for the two methods but constructing `N` for the sparse case is very slow...