### PR TITLE
PINT compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ install:
     - pip install libstempo --install-option="--with-tempo2=$TEMPO2"
 
 script:
-    - coverage run --source enterprise setup.py test
+    #- coverage run --source enterprise setup.py test
+    - make test
     - make lint
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ install:
     - pip install libstempo --install-option="--with-tempo2=$TEMPO2"
 
 script:
-    #- coverage run --source enterprise setup.py test
     - make test
     - make lint
 

--- a/enterprise/pulsar.py
+++ b/enterprise/pulsar.py
@@ -362,7 +362,7 @@ def Pulsar(*args, **kwargs):
     planets = kwargs.get('planets', True)
     sort = kwargs.get('sort', True)
     drop_t2pulsar = kwargs.get('drop_t2pulsar', True)
-    timing_package = kwargs.get('timing_package', 'pint')
+    timing_package = kwargs.get('timing_package', 'tempo2')
 
     toas = filter(lambda x: isinstance(x, toa.TOAs), args)
     model = filter(lambda x: isinstance(x, TimingModel), args)

--- a/enterprise/pulsar.py
+++ b/enterprise/pulsar.py
@@ -257,6 +257,14 @@ class PintPulsar(BasePulsar):
         self._ssbfreqs = np.array(model.barycentric_radio_freq(toas.table),
                                   dtype='float64')
 
+        # fitted parameters
+        self.fitpars = ['Offset'] + [par for par in model.params
+                                     if not getattr(model, par).frozen]
+
+        # set parameters
+        spars = [par for par in model.params]
+        self.setpars = [sp for sp in spars if sp not in self.fitpars]
+
         self._flags = {}
         for ii, obsflags in enumerate(toas.get_flags()):
             for jj, flag in enumerate(obsflags):
@@ -309,6 +317,13 @@ class Tempo2Pulsar(BasePulsar):
         self._toaerrs = np.double(t2pulsar.toaerrs) * 1e-6
         self._designmatrix = np.double(t2pulsar.designmatrix())
         self._ssbfreqs = np.double(t2pulsar.ssbfreqs()) / 1e6
+
+        # fitted parameters
+        self.fitpars = ['Offset'] + list(map(str, t2pulsar.pars()))
+
+        # set parameters
+        spars = list(map(str, t2pulsar.pars(which='set')))
+        self.setpars = [sp for sp in spars if sp not in self.fitpars]
 
         self._flags = {}
         for key in t2pulsar.flags():

--- a/enterprise/pulsar.py
+++ b/enterprise/pulsar.py
@@ -327,7 +327,7 @@ class Tempo2Pulsar(BasePulsar):
     def _get_radec(self, t2pulsar):
         if 'RAJ' in np.concatenate((t2pulsar.pars(which='fit'),
                                     t2pulsar.pars(which='set'))):
-            return (np.double(t2pulsar['RAJ'].val), 
+            return (np.double(t2pulsar['RAJ'].val),
                     np.double(t2pulsar['DECJ'].val))
 
         else:

--- a/enterprise/pulsar.py
+++ b/enterprise/pulsar.py
@@ -327,8 +327,8 @@ class Tempo2Pulsar(BasePulsar):
     def _get_radec(self, t2pulsar):
         if 'RAJ' in np.concatenate((t2pulsar.pars(which='fit'),
                                     t2pulsar.pars(which='set'))):
-            return np.double(t2pulsar['RAJ'].val),
-            np.double(t2pulsar['DECJ'].val)
+            return (np.double(t2pulsar['RAJ'].val), 
+                    np.double(t2pulsar['DECJ'].val))
 
         else:
             # use ecliptic coordinates

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ scipy==0.18.1
 ephem==3.7.6.0
 Cython==0.25.2
 scikit-sparse>=0.4.2
+git+https://github.com/nanograv/PINT.git
+jplephem==2.6

--- a/tests/test_deterministic_signals.py
+++ b/tests/test_deterministic_signals.py
@@ -91,3 +91,15 @@ class TestDeterministicSignals(unittest.TestCase):
         # test
         msg = 'Delay incorrect.'
         assert np.all(m.get_delay(params) == delay), msg
+
+
+class TestDeterministicSignalsPint(TestDeterministicSignals):
+
+    @classmethod
+    def setUpClass(cls):
+        """Setup the Pulsar object."""
+
+        # initialize Pulsar class
+        cls.psr = Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
+                         datadir + '/B1855+09_NANOGrav_9yv1.tim',
+                         ephem='DE430', timing_package='pint')

--- a/tests/test_deterministic_signals.py
+++ b/tests/test_deterministic_signals.py
@@ -28,12 +28,13 @@ def sine_wave(toas, log10_A=-7, log10_f=-8, phase=0.0):
 
 class TestDeterministicSignals(unittest.TestCase):
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         """Setup the Pulsar object."""
 
         # initialize Pulsar class
-        self.psr = Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
-                          datadir + '/B1855+09_NANOGrav_9yv1.tim')
+        cls.psr = Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
+                         datadir + '/B1855+09_NANOGrav_9yv1.tim')
 
     def test_delay(self):
         """Test deterministic signal no selection."""

--- a/tests/test_gp_signals.py
+++ b/tests/test_gp_signals.py
@@ -23,12 +23,13 @@ from enterprise.signals import utils
 
 class TestGPSignals(unittest.TestCase):
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         """Setup the Pulsar object."""
 
         # initialize Pulsar class
-        self.psr = Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
-                          datadir + '/B1855+09_NANOGrav_9yv1.tim')
+        cls.psr = Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
+                         datadir + '/B1855+09_NANOGrav_9yv1.tim')
 
     def test_ecorr(self):
         """Test that ecorr signal returns correct values."""

--- a/tests/test_gp_signals.py
+++ b/tests/test_gp_signals.py
@@ -470,3 +470,15 @@ class TestGPSignals(unittest.TestCase):
         # test shape
         msg = 'Basis matrix shape incorrect size for combined signal.'
         assert m.get_basis(params).shape == T.shape, msg
+
+
+class TestGPSignalsPint(TestGPSignals):
+
+    @classmethod
+    def setUpClass(cls):
+        """Setup the Pulsar object."""
+
+        # initialize Pulsar class
+        cls.psr = Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
+                         datadir + '/B1855+09_NANOGrav_9yv1.tim',
+                         ephem='DE430', timing_package='pint')

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -252,3 +252,18 @@ class TestLikelihood(unittest.TestCase):
         l1 = pta1.get_lnlikelihood(params)
         l2 = pta2.get_lnlikelihood(params)
         assert np.allclose(l1, l2), msg
+
+
+class TestLikelihoodPint(TestLikelihood):
+
+    @classmethod
+    def setUpClass(cls):
+        """Setup the Pulsar object."""
+
+        # initialize Pulsar class
+        cls.psrs = [Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
+                           datadir + '/B1855+09_NANOGrav_9yv1.tim',
+                           ephem='DE430', timing_package='pint'),
+                    Pulsar(datadir + '/J1909-3744_NANOGrav_9yv1.gls.par',
+                           datadir + '/J1909-3744_NANOGrav_9yv1.tim',
+                           ephem='DE430', timing_package='pint')]

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -59,14 +59,15 @@ def get_noise_from_pal2(noisefile):
 
 class TestLikelihood(unittest.TestCase):
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         """Setup the Pulsar object."""
 
         # initialize Pulsar class
-        self.psrs = [Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
-                            datadir + '/B1855+09_NANOGrav_9yv1.tim'),
-                     Pulsar(datadir + '/J1909-3744_NANOGrav_9yv1.gls.par',
-                            datadir + '/J1909-3744_NANOGrav_9yv1.tim')]
+        cls.psrs = [Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
+                           datadir + '/B1855+09_NANOGrav_9yv1.tim'),
+                    Pulsar(datadir + '/J1909-3744_NANOGrav_9yv1.gls.par',
+                           datadir + '/J1909-3744_NANOGrav_9yv1.tim')]
 
     def compute_like(self, npsrs=1, inc_corr=False):
 

--- a/tests/test_pta.py
+++ b/tests/test_pta.py
@@ -341,3 +341,18 @@ class TestPTASignals(unittest.TestCase):
         msg = 'PTA Phi inverse is incorrect {}.'.format(params)
         assert np.allclose(phiinv, np.linalg.inv(phit),
                            rtol=1e-15, atol=1e-17), msg
+
+
+class TestPTASignalsPint(TestPTASignals):
+
+    @classmethod
+    def setUpClass(cls):
+        """Setup the Pulsar object."""
+
+        # initialize Pulsar class
+        cls.psrs = [Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
+                           datadir + '/B1855+09_NANOGrav_9yv1.tim',
+                           ephem='DE430', timing_package='pint'),
+                    Pulsar(datadir + '/J1909-3744_NANOGrav_9yv1.gls.par',
+                           datadir + '/J1909-3744_NANOGrav_9yv1.tim',
+                           ephem='DE430', timing_package='pint')]

--- a/tests/test_pta.py
+++ b/tests/test_pta.py
@@ -9,8 +9,8 @@ Tests for common signal and PTA class modules.
 """
 
 
-import os
-import pickle
+#import os
+#import pickle
 import itertools
 import unittest
 
@@ -62,21 +62,26 @@ def hd_powerlaw(f, pos1, pos2, log10_A=-15, gamma=4.3):
 
 class TestPTASignals(unittest.TestCase):
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         """Setup the Pulsar object."""
 
-        if os.path.isfile(datadir + '/B1855+09.pkl') and \
-                os.path.isfile(datadir + '/J1909-3744.pkl'):
-            self.psrs = [pickle.load(open(datadir + '/B1855+09.pkl','r')),
-                         pickle.load(open(datadir + '/J1909-3744.pkl','r'))]
-        else:
-            self.psrs = [Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
-                                datadir + '/B1855+09_NANOGrav_9yv1.tim'),
-                         Pulsar(datadir + '/J1909-3744_NANOGrav_9yv1.gls.par',
-                                datadir + '/J1909-3744_NANOGrav_9yv1.tim')]
-
-            for psr in self.psrs:
-                psr.to_pickle(datadir)
+        #if os.path.isfile(datadir + '/B1855+09.pkl') and \
+        #        os.path.isfile(datadir + '/J1909-3744.pkl'):
+        #    self.psrs = [pickle.load(open(datadir + '/B1855+09.pkl','r')),
+        #                 pickle.load(open(datadir + '/J1909-3744.pkl','r'))]
+        #else:
+        #    self.psrs = [Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
+        #                        datadir + '/B1855+09_NANOGrav_9yv1.tim'),
+        #                 Pulsar(datadir + '/J1909-3744_NANOGrav_9yv1.gls.par',
+        #                        datadir + '/J1909-3744_NANOGrav_9yv1.tim')]
+#
+        #    for psr in self.psrs:
+        #        psr.to_pickle(datadir)
+        cls.psrs = [Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
+                           datadir + '/B1855+09_NANOGrav_9yv1.tim'),
+                    Pulsar(datadir + '/J1909-3744_NANOGrav_9yv1.gls.par',
+                           datadir + '/J1909-3744_NANOGrav_9yv1.tim')]
 
     def test_parameterized_orf(self):
         T1 = 3.16e8

--- a/tests/test_pulsar.py
+++ b/tests/test_pulsar.py
@@ -19,12 +19,13 @@ import cPickle as pickle
 
 class TestPulsar(unittest.TestCase):
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         """Setup the Pulsar object."""
 
         # initialize Pulsar class
-        self.psr = Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
-                          datadir + '/B1855+09_NANOGrav_9yv1.tim')
+        cls.psr = Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
+                         datadir + '/B1855+09_NANOGrav_9yv1.tim')
 
     def test_residuals(self):
         """Check Residual shape."""

--- a/tests/test_pulsar.py
+++ b/tests/test_pulsar.py
@@ -104,3 +104,15 @@ class TestPulsar(unittest.TestCase):
 
             msg = 'Cannot find parfile wrong.par or timfile wrong.tim!'
             self.assertTrue(msg in context.exception)
+
+
+class TestPulsarPint(TestPulsar):
+
+    @classmethod
+    def setUpClass(cls):
+        """Setup the Pulsar object."""
+
+        # initialize Pulsar class
+        cls.psr = Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
+                         datadir + '/B1855+09_NANOGrav_9yv1.tim',
+                         ephem='DE430', timing_package='pint')

--- a/tests/test_set_parameter.py
+++ b/tests/test_set_parameter.py
@@ -59,14 +59,15 @@ def get_noise_from_pal2(noisefile):
 
 class TestSetParameters(unittest.TestCase):
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         """Setup the Pulsar object."""
 
         # initialize Pulsar class
-        self.psrs = [Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
-                            datadir + '/B1855+09_NANOGrav_9yv1.tim'),
-                     Pulsar(datadir + '/J1909-3744_NANOGrav_9yv1.gls.par',
-                            datadir + '/J1909-3744_NANOGrav_9yv1.tim')]
+        cls.psrs = [Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
+                           datadir + '/B1855+09_NANOGrav_9yv1.tim'),
+                    Pulsar(datadir + '/J1909-3744_NANOGrav_9yv1.gls.par',
+                           datadir + '/J1909-3744_NANOGrav_9yv1.tim')]
 
     def test_single_pulsar(self):
 

--- a/tests/test_set_parameter.py
+++ b/tests/test_set_parameter.py
@@ -306,3 +306,18 @@ class TestSetParameters(unittest.TestCase):
             # inverse spectrum test
             msg = 'Spectrum inverse incorrect for GP Fourier signal.'
             assert np.all(pphiinv == 1/phi), msg
+
+
+class TestSetParametersPint(TestSetParameters):
+
+    @classmethod
+    def setUpClass(cls):
+        """Setup the Pulsar object."""
+
+        # initialize Pulsar class
+        cls.psrs = [Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
+                           datadir + '/B1855+09_NANOGrav_9yv1.tim',
+                           ephem='DE430', timing_package='pint'),
+                    Pulsar(datadir + '/J1909-3744_NANOGrav_9yv1.gls.par',
+                           datadir + '/J1909-3744_NANOGrav_9yv1.tim',
+                           ephem='DE430', timing_package='pint')]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,23 +18,24 @@ import enterprise.constants as const
 
 class TestUtils(unittest.TestCase):
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         """Setup the Pulsar object."""
 
         # initialize Pulsar class
-        self.psr = Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
-                          datadir + '/B1855+09_NANOGrav_9yv1.tim')
-        self.F, _ = utils.createfourierdesignmatrix_red(
-            self.psr.toas, nmodes=30)
-        self.Fdm, _ = utils.createfourierdesignmatrix_dm(
-            self.psr.toas,freqs=self.psr.freqs, nmodes=30)
-        tmp = utils.createfourierdesignmatrix_eph(t=self.psr.toas,
-                                                  phi=self.psr.phi,
-                                                  theta=self.psr.theta,
+        cls.psr = Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
+                         datadir + '/B1855+09_NANOGrav_9yv1.tim')
+        cls.F, _ = utils.createfourierdesignmatrix_red(
+            cls.psr.toas, nmodes=30)
+        cls.Fdm, _ = utils.createfourierdesignmatrix_dm(
+            cls.psr.toas,freqs=cls.psr.freqs, nmodes=30)
+        tmp = utils.createfourierdesignmatrix_eph(t=cls.psr.toas,
+                                                  phi=cls.psr.phi,
+                                                  theta=cls.psr.theta,
                                                   nmodes=30)
-        self.Fx, self.Fy, self.Fz = tmp
+        cls.Fx, cls.Fy, cls.Fz = tmp
 
-        self.Mm = utils.create_stabletimingdesignmatrix(self.psr.Mmat)
+        cls.Mm = utils.create_stabletimingdesignmatrix(cls.psr.Mmat)
 
     def test_createstabletimingdesignmatrix(self):
         """Timing model design matrix shape."""

--- a/tests/test_white_signals.py
+++ b/tests/test_white_signals.py
@@ -391,30 +391,30 @@ class TestWhiteSignals(unittest.TestCase):
         msg = 'EFAC/ECORR {} logdet incorrect.'.format(method)
         N = m.get_ndiag(params)
         assert np.allclose(N.solve(self.ipsr.residuals, logdet=True)[1],
-                           wd.logdet(), rtol=1e-10), msg
+                           wd.logdet(), rtol=1e-8), msg
 
         msg = 'EFAC/ECORR {} D1 solve incorrect.'.format(method)
         assert np.allclose(N.solve(self.ipsr.residuals),
-                           wd.solve(self.ipsr.residuals), rtol=1e-10), msg
+                           wd.solve(self.ipsr.residuals), rtol=1e-8), msg
 
         msg = 'EFAC/ECORR {} 1D1 solve incorrect.'.format(method)
         assert np.allclose(
             N.solve(self.ipsr.residuals, left_array=self.ipsr.residuals),
             np.dot(self.ipsr.residuals, wd.solve(self.ipsr.residuals)),
-            rtol=1e-10), msg
+            rtol=1e-8), msg
 
         msg = 'EFAC/ECORR {} 2D1 solve incorrect.'.format(method)
         T = m.get_basis()
         assert np.allclose(
             N.solve(self.ipsr.residuals, left_array=T),
             np.dot(T.T, wd.solve(self.ipsr.residuals)),
-            rtol=1e-10), msg
+            rtol=1e-8), msg
 
         msg = 'EFAC/ECORR {} 2D2 solve incorrect.'.format(method)
         assert np.allclose(
             N.solve(T, left_array=T),
             np.dot(T.T, wd.solve(T)),
-            rtol=1e-10), msg
+            rtol=1e-8), msg
 
     def test_ecorr_sparse(self):
         """Test of sparse ecorr signal and solve methods."""

--- a/tests/test_white_signals.py
+++ b/tests/test_white_signals.py
@@ -439,3 +439,20 @@ class TestWhiteSignals(unittest.TestCase):
     def test_ecorr_block_ipta(self):
         """Test of block matrix ecorr signal and solve methods."""
         self._ecorr_test_ipta(method='block')
+
+
+class TestWhiteSignalsPint(TestWhiteSignals):
+
+    @classmethod
+    def setUpClass(cls):
+        """Setup the Pulsar object."""
+
+        # initialize Pulsar class
+        cls.psr = Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
+                         datadir + '/B1855+09_NANOGrav_9yv1.tim',
+                         ephem='DE430', timing_package='pint')
+
+        # IPTA-like pulsar
+        cls.ipsr = Pulsar(datadir + '/1713.Sep.T2.par',
+                          datadir + '/1713.Sep.T2.tim',
+                          ephem='DE421', timint_package='pint')

--- a/tests/test_white_signals.py
+++ b/tests/test_white_signals.py
@@ -55,16 +55,17 @@ class Woodbury(object):
 
 class TestWhiteSignals(unittest.TestCase):
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         """Setup the Pulsar object."""
 
         # initialize Pulsar class
-        self.psr = Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
-                          datadir + '/B1855+09_NANOGrav_9yv1.tim')
+        cls.psr = Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
+                         datadir + '/B1855+09_NANOGrav_9yv1.tim')
 
         # IPTA-like pulsar
-        self.ipsr = Pulsar(datadir + '/1713.Sep.T2.par',
-                           datadir + '/1713.Sep.T2.tim')
+        cls.ipsr = Pulsar(datadir + '/1713.Sep.T2.par',
+                          datadir + '/1713.Sep.T2.tim')
 
     def test_efac(self):
         """Test that efac signal returns correct covariance."""


### PR DESCRIPTION
So here is a first stab at `PINT` compatibility. I have re-factored `pulsar.py` to have a base `BasePulsar` class that has all of the standard properties that the user calls, then I have `Tempo2Pulsar` and `PintPulsar` that inherit `BasePulsar` and get the needed information from either a `libstempo` instance or from a `TOA` and `TimingModel` instance depending on whether or not you are using `tempo2` or `PINT`.

From this I now have a *function* `Pulsar` that you initialize a `Pulsar` class from. It has the same API as the old `Pulsar` class except it now has an extra argument `timing_code`, which defaults to `tempo2`. You can also initialize this with the usual par and tim file, or you can initialize it with `libstempo` or `PINT` objects.

One reason for doing things this was is that the `Tempo2Pulsar` and `PintPulsar` classes act as a bridge between codes. Here we have a way for `enterprise` to call either code but now `libstempo` or `PINT` could call enterprise by initializing these classes internally.

I have to set up more tests but this is coming along. Also speaking of tests, I switched from using `setUp` to `setUpClass` in the unit tests since `setUp` is called *every* time a test function is called whereas `setUpClass` is called only at the beginning of each test case. This takes the test runtime down to a few minutes from what was about 20 minutes.