### PR TITLE
Fix a few bugs

### DIFF
--- a/enterprise/pulsar.py
+++ b/enterprise/pulsar.py
@@ -423,7 +423,7 @@ def Pulsar(*args, **kwargs):
         elif timing_package.lower() == 'tempo2':
 
             # hack to set maxobs
-            maxobs = get_maxobs(reltimfile)
+            maxobs = get_maxobs(reltimfile) + 100
             t2pulsar = t2.tempopulsar(relparfile, reltimfile,
                                       maxobs=maxobs, ephem=ephem)
             os.chdir(cwd)

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -525,7 +525,7 @@ def SignalCollection(metasignals):
                     self.white_params.extend(signal.ndiag_params)
                 elif signal.signal_type in ['basis', 'common basis']:
                     self.basis_params.extend(signal.basis_params)
-                elif signal.signal_type == 'delay':
+                elif signal.signal_type == 'deterministic':
                     self.delay_params.extend(signal.delay_params)
 
         # a candidate for memoization

--- a/enterprise/signals/utils.py
+++ b/enterprise/signals/utils.py
@@ -123,7 +123,8 @@ def createfourierdesignmatrix_dm(toas, freqs, nmodes=30, Tspan=None,
 
     # compute the DM-variation vectors
     # TODO: should we use a different normalization
-    Dm = 1.0/(const.DM_K * freqs**2 * 1e12)
+    #Dm = 1.0/(const.DM_K * freqs**2 * 1e12)
+    Dm = (1400/freqs)**2
 
     return F * Dm[:, None], Ffreqs
 


### PR DESCRIPTION
This is a simple PR to fix a few bugs:

1. There was a bug that cause the deterministic signals to not be updated while sampling.
2. For some reason, libstempo (maybe tempo2) would fail on the NANOGrav 5 year data if we use `maxobs` exactly equal to the number of TOAs. I have just added 100 to `maxobs` when initializing the `Pulsar` for now.
3. I changed the scaling for the DM fourier design matrix to (1400/freqs)**2. I think this is better than using some constant because this is dimensionless and it lets us used the same parameterization for DM processes and red noise processes.