### PR TITLE
2D Kernels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,8 @@ install:
     - cd ../
 
 script:
-    - coverage run --source enterprise setup.py test
+    - make test
+    #- coverage run --source enterprise setup.py test
     - make lint
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 #cache: pip
-#dist: precise
+dist: precise
 
 python:
     - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,39 @@ install:
     - cd ..
     - rm -rf psrsoft-tempo2-*
 
+    - sudo apt-get update
+    # We do this conditionally because it saves us some downloading if the
+    # version is the same.
+    - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+        wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+      else
+        wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+      fi
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - export PATH="$HOME/miniconda/bin:$PATH"
+    - hash -r
+    - conda config --set always_yes yes --set changeps1 no
+    - conda update -q conda
+    # Useful for debugging any issues with conda
+    - conda info -a
+
+    # Replace dep1 dep2 ... with your dependencies
+    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION 
+    - source activate test-environment
     - pip install -r requirements_dev.txt
     - pip install -r requirements.txt
     - git clone https://github.com/vallis/libstempo.git
     - cd libstempo
     - python setup.py install --with-tempo2=$TEMPO2
     - cd ../
+    - python setup.py install
+
+    #- pip install -r requirements_dev.txt
+    #- pip install -r requirements.txt
+    #- git clone https://github.com/vallis/libstempo.git
+    #- cd libstempo
+    #- python setup.py install --with-tempo2=$TEMPO2
+    #- cd ../
 
 script:
     - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,8 +65,8 @@ install:
     #- cd ../
 
 script:
-    - make test
-    #- coverage run --source enterprise setup.py test
+    #- make test
+    - coverage run --source enterprise setup.py test
     - make lint
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-cache: pip
+#cache: pip
 #dist: precise
 
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 cache: pip
-dist: precise
+#dist: precise
 
 python:
     - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,18 +43,11 @@ install:
     - conda info -a
 
     # Replace dep1 dep2 ... with your dependencies
-    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy cython
+    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy
     - source activate test-environment
-    - pip install -r requirements_dev.txt
     - pip install -r requirements.txt
-    - git clone https://github.com/vallis/libstempo.git
-    - cd libstempo
-    - python setup.py install --with-tempo2=$TEMPO2
-    - cd ../
-
-    # hack
-    - pip install -U scikit-sparse
-
+    - pip install -r requirements_dev.txt
+    - pip install git+https://github.com/vallis/libstempo.git --install-option="--with-tempo2=$TEMPO2"
     - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
     - conda info -a
 
     # Replace dep1 dep2 ... with your dependencies
-    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy cython 
+    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy cython
     - source activate test-environment
     - pip install -r requirements_dev.txt
     - pip install -r requirements.txt
@@ -51,6 +51,10 @@ install:
     - cd libstempo
     - python setup.py install --with-tempo2=$TEMPO2
     - cd ../
+
+    # hack
+    - pip install -U scikit-sparse
+
     - python setup.py install
 
     #- pip install -r requirements_dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ install:
     - conda info -a
 
     # Replace dep1 dep2 ... with your dependencies
-    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION 
+    - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy cython 
     - source activate test-environment
     - pip install -r requirements_dev.txt
     - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,13 +57,6 @@ install:
 
     - python setup.py install
 
-    #- pip install -r requirements_dev.txt
-    #- pip install -r requirements.txt
-    #- git clone https://github.com/vallis/libstempo.git
-    #- cd libstempo
-    #- python setup.py install --with-tempo2=$TEMPO2
-    #- cd ../
-
 script:
     #- make test
     - coverage run --source enterprise setup.py test

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr htmlcov/
 
 lint: ## check style with flake8
-	flake8 --ignore=E265,E226,E231,E731 enterprise tests
+	flake8 --ignore=E265,E226,E231,E731,E722 enterprise tests
 
 test: ## run tests quickly with the default Python
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,18 +7,18 @@ Installation
 
 .. Stable release
 .. --------------
-.. 
+..
 .. To install enterprise, run this command in your terminal:
-.. 
+..
 .. .. code-block:: console
-.. 
+..
 ..     $ pip install enterprise
-.. 
-.. This is the preferred method to install enterprise, as it will always install the most recent stable release. 
-.. 
+..
+.. This is the preferred method to install enterprise, as it will always install the most recent stable release.
+..
 .. If you don't have `pip`_ installed, this `Python installation guide`_ can guide
 .. you through the process.
-.. 
+..
 .. .. _pip: https://pip.pypa.io
 .. .. _Python installation guide: http://docs.python-guide.org/en/latest/starting/installation/
 
@@ -43,11 +43,15 @@ Or download the `tarball`_:
 Once you have a copy of the source, you can install it with:
 
 .. code-block:: console
-
+    $ pip install numpy
     $ pip install -r requirements.txt
     $ pip install git+https://github.com/vallis/libstempo.git --install-option="--with-tempo2=$TEMPO2"
     $ python setup.py install
 
+If you want to run tests or do any other development then also run:
+
+.. code-block:: console
+    $ pip install -r requirements_dev.txt
 
 .. _Github repo: https://github.com/nanograv/enterprise
 .. _tarball: https://github.com/nanograv/enterprise/tarball/master

--- a/enterprise/signals/gp_signals.py
+++ b/enterprise/signals/gp_signals.py
@@ -62,7 +62,7 @@ def BasisGP(priorFunction, basisFunction,
 
             nc = np.sum(F.shape[1] for F in basis.values())
             self._basis = np.zeros((len(self._masks[0]), nc))
-            self._phi = np.zeros(nc)
+            self._phi = base.KernelMatrix(nc)
             self._slices = {}
             nctot = 0
             for key, mask in zip(self._keys, self._masks):
@@ -79,12 +79,13 @@ def BasisGP(priorFunction, basisFunction,
         def get_phi(self, params):
             self._construct_basis(params)
             for key, slc in self._slices.items():
-                self._phi[slc] = self._prior[key](
+                phislc = self._prior[key](
                     self._labels[key], params=params) * self._labels[key][0]
+                self._phi = self._phi.set(phislc, slc)
             return self._phi
 
         def get_phiinv(self, params):
-            return 1 / self.get_phi(params)
+            return self.get_phi(params).inv()
 
     return BasisGP
 

--- a/enterprise/signals/gp_signals.py
+++ b/enterprise/signals/gp_signals.py
@@ -80,7 +80,7 @@ def BasisGP(priorFunction, basisFunction,
             self._construct_basis(params)
             for key, slc in self._slices.items():
                 phislc = self._prior[key](
-                    self._labels[key], params=params) * self._labels[key][0]
+                    self._labels[key], params=params)
                 self._phi = self._phi.set(phislc, slc)
             return self._phi
 
@@ -197,14 +197,14 @@ def BasisCommonGP(priorFunction, basisFunction, orfFunction, name='common'):
         def get_phi(self, params):
             self._construct_basis(params)
             prior = BasisCommonGP._prior(
-                self._labels, params=params) * self._labels[0]
+                self._labels, params=params)
             orf = BasisCommonGP._orf(self._psrpos, self._psrpos, params=params)
             return prior * orf
 
         @classmethod
         def get_phicross(cls, signal1, signal2, params):
             prior = BasisCommonGP._prior(signal1._labels,
-                                         params=params) * signal1._labels[0]
+                                         params=params)
             orf = BasisCommonGP._orf(signal1._psrpos, signal2._psrpos,
                                      params=params)
             return prior * orf

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -325,12 +325,12 @@ class PTA(object):
 
             #TODO: This is messy, maybe we should clean up
             phis = [phivec for phivec in phivecs if phivec is not None]
-            if np.any([phivec.ndim==2 for phivec in phis]):
+            if np.any([phivec.ndim == 2 for phivec in phis]):
                 phiinvs = [phivec.inv(logdet) for phivec in phis]
                 phiinv = sl.block_diag(*[pi[0] for pi in phiinvs])
                 if logdet:
                     ld = np.sum([pi[1] for pi in phiinvs])
-                phidiag = np.concatenate([np.diag(phi) if phi.ndim==2
+                phidiag = np.concatenate([np.diag(phi) if phi.ndim == 2
                                           else phi for phi in phis])
             else:
                 phidiag = np.concatenate(phis)
@@ -473,7 +473,7 @@ class PTA(object):
         if self._commonsignals:
             # would be easier if get_phi would return an empty array
             phis = [phivec for phivec in phivecs if phivec is not None]
-            if np.any([phivec.ndim==2 for phivec in phis]):
+            if np.any([phivec.ndim == 2 for phivec in phis]):
                 phi = sl.block_diag(*phis)
                 phidiag = np.diag(phi)
             else:

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -327,7 +327,9 @@ class PTA(object):
             phis = [phivec for phivec in phivecs if phivec is not None]
             if np.any([phivec.ndim == 2 for phivec in phis]):
                 phiinvs = [phivec.inv(logdet) for phivec in phis]
-                phiinv = sl.block_diag(*[pi[0] for pi in phiinvs])
+                phiinv_full = [np.diag(phi[0]) if phi[0].ndim == 1 else phi[0]
+                               for phi in phiinvs]
+                phiinv = sl.block_diag(*phiinv_full)
                 if logdet:
                     ld = np.sum([pi[1] for pi in phiinvs])
                 phidiag = np.concatenate([np.diag(phi) if phi.ndim == 2
@@ -474,7 +476,9 @@ class PTA(object):
             # would be easier if get_phi would return an empty array
             phis = [phivec for phivec in phivecs if phivec is not None]
             if np.any([phivec.ndim == 2 for phivec in phis]):
-                phi = sl.block_diag(*phis)
+                phi_full = [np.diag(phi) if phi.ndim == 1 else phi
+                            for phi in phis]
+                phi = sl.block_diag(*phi_full)
                 phidiag = np.diag(phi)
             else:
                 phidiag = np.concatenate(phis)

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -595,7 +595,7 @@ def SignalCollection(metasignals):
             matrix to save computations when calling `get_basis` later.
             """
 
-            idx, Fmatlist = {}, []
+            idx, Fmatlist, hashlist = {}, [], []
             cc = 0
             for signal in signals:
                 Fmat = signal.get_basis()
@@ -604,15 +604,15 @@ def SignalCollection(metasignals):
                     idx[signal] = []
 
                     for i, column in enumerate(Fmat.T):
-                        for j, savedcolumn in enumerate(Fmatlist):
-                            if np.allclose(column,savedcolumn,rtol=1e-15):
-                                idx[signal].append(j)
-                                break
-                        else:
+                        colhash = hash(column.tostring())
+                        try:
+                            j = hashlist.index(colhash)
+                            idx[signal].append(j)
+                        except ValueError:
                             idx[signal].append(cc)
                             Fmatlist.append(column)
+                            hashlist.append(colhash)
                             cc += 1
-
                 elif Fmat is not None and signal.basis_params:
                     nf = Fmat.shape[1]
                     idx[signal] = list(np.arange(cc, cc+nf))

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -285,7 +285,7 @@ class PTA(object):
     def _get_slices(self, phivecs):
         ret, offset = {}, 0
         for sc, phivec in zip(self._signalcollections, phivecs):
-            # assume phi is either a column vector or a square matrix 
+            # assume phi is either a column vector or a square matrix
             stop = 0 if phivec is None else phivec.shape[0]
             ret[sc] = slice(offset, offset+stop)
             offset = ret[sc].stop
@@ -462,7 +462,7 @@ class PTA(object):
 
         # loop over vectors of common-signal-correlated global-indices
         for idxs in idxmatrix:
-            # find the existing cliques assigned to these global indices 
+            # find the existing cliques assigned to these global indices
             allidx = set(self._cliques[idxs])
             maxidx = max(allidx)
 
@@ -497,10 +497,11 @@ class PTA(object):
             if phi is not None:
                 for clindex in range(getattr(phi, '_clcount', 0)):
                     phiind = np.where(phi._cliques == clindex)[0]
-                    
+
                     if len(phiind) > 0:
                         try:
-                            self._cliques[slices[sc].start + phiind] = self._clcount
+                            self._cliques[slices[sc].start+phiind] = (
+                                self._clcount)
                             self._clcount = self._clcount + 1
                         except:
                             print(self._cliques.shape)
@@ -516,7 +517,7 @@ class PTA(object):
         # otherwise a list of phivec vectors (some of which possibly None)
         if self._commonsignals:
             if np.any([phi.ndim == 2 for phi in phis if phi is not None]):
-                # if we have any dense matrices, 
+                # if we have any dense matrices,
                 Phi = sl.block_diag(*[np.diag(phi) if phi.ndim == 1 else phi
                                       for phi in phis
                                       if phi is not None])
@@ -524,12 +525,12 @@ class PTA(object):
                 Phi = np.diag(np.concatenate([phi for phi in phis
                                               if phi is not None]))
 
-            # get a dictionary of slices locating each pulsar in Phi matrix 
+            # get a dictionary of slices locating each pulsar in Phi matrix
             slices = self._get_slices(phis)
 
             # self._cliques is a vector of the same size as the Phi matrix
             # for each Phi index i, self._cliques[i] is -1 if row/column
-            # belong to no clique, or it gives the clique number otherwise 
+            # belong to no clique, or it gives the clique number otherwise
             if cliques:
                 self._resetcliques(Phi.shape[0])
                 self._setpulsarcliques(slices, phis)
@@ -927,7 +928,7 @@ class KernelMatrix(np.ndarray):
                 idx = ((idx, idx) if isinstance(idx, slice)
                        else (idx[:, None], idx))
                 self[idx] += other
-                
+
         return self
 
     def set(self, other, idx):

--- a/enterprise/signals/utils.py
+++ b/enterprise/signals/utils.py
@@ -52,7 +52,6 @@ def createfourierdesignmatrix_red(toas, nmodes=30, Tspan=None,
                                   pshift=False):
     """
     Construct fourier design matrix from eq 11 of Lentati et al, 2013
-
     :param toas: vector of time series in seconds
     :param nmodes: number of fourier coefficients to use
     :param freq: option to output frequencies
@@ -61,7 +60,6 @@ def createfourierdesignmatrix_red(toas, nmodes=30, Tspan=None,
     :param fmin: lower sampling frequency
     :param fmax: upper sampling frequency
     :param pshift: option to add random phase shift
-
     :return: F: fourier design matrix
     :return: f: Sampling frequencies
     """
@@ -72,15 +70,23 @@ def createfourierdesignmatrix_red(toas, nmodes=30, Tspan=None,
     T = Tspan if Tspan is not None else toas.max() - toas.min()
 
     # define sampling frequencies
-    if fmin is None:
-        fmin = 1 / T
-    if fmax is None:
-        fmax = nmodes / T
-
-    if logf:
-        f = np.logspace(np.log10(fmin), np.log10(fmax), nmodes)
+    if fmin is None and fmax is None and not logf:
+        # make sure partially overlapping sets of modes
+        # have identical frequencies
+        f = 1.0 * np.arange(1, nmodes + 1) / T
     else:
-        f = np.linspace(fmin, fmax, nmodes)
+        # more general case
+
+        if fmin is None:
+            fmin = 1 / T
+
+        if fmax is None:
+            fmax = nmodes / T
+
+        if logf:
+            f = np.logspace(np.log10(fmin), np.log10(fmax), nmodes)
+        else:
+            f = np.linspace(fmin, fmax, nmodes)
 
     # add random phase shift to basis functions
     ranphase = (np.random.uniform(0.0, 2 * np.pi, nmodes)

--- a/enterprise/signals/utils.py
+++ b/enterprise/signals/utils.py
@@ -689,8 +689,7 @@ def hd_orf(pos1, pos2):
     if np.all(pos1 == pos2):
         return 1
     else:
-        xi = 1 - np.dot(pos1, pos2)
-        omc2 = (1 - np.cos(xi)) / 2
+        omc2 = (1 - np.dot(pos1, pos2)) / 2
         return 1.5 * omc2 * np.log(omc2) - 0.25 * omc2 + 0.5
 
 

--- a/enterprise/signals/utils.py
+++ b/enterprise/signals/utils.py
@@ -671,6 +671,31 @@ def quant2ind(U):
     return inds
 
 
+def linear_interp_basis(toas, dt=30*86400):
+    """Provides a basis for linear interpolation.
+
+    :param toas: Pulsar TOAs in seconds
+    :param dt: Linear interpolation step size in seconds.
+
+    :returns: Linear interpolation basis and nodes
+    """
+
+    # evenly spaced points
+    x = np.arange(toas.min(), toas.max()+dt, dt)
+    M = np.zeros((len(toas), len(x)))
+
+    # make linear interpolation basis
+    for ii in range(len(x)-1):
+        idx = np.logical_and(toas >= x[ii], toas <= x[ii+1])
+        M[idx, ii] = (toas[idx] - x[ii+1]) / (x[ii] - x[ii+1])
+        M[idx, ii+1] = (toas[idx] - x[ii]) / (x[ii+1] - x[ii])
+
+    # only return non-zero columns
+    idx = M.sum(axis=0) != 0
+
+    return M[:, idx], x[idx]
+
+
 @signal_base.function
 def powerlaw(f, log10_A=-16, gamma=5):
     df = np.diff(np.concatenate((np.array([0]), f[::2])))

--- a/enterprise/signals/utils.py
+++ b/enterprise/signals/utils.py
@@ -673,15 +673,17 @@ def quant2ind(U):
 
 @signal_base.function
 def powerlaw(f, log10_A=-16, gamma=5):
+    df = np.diff(np.concatenate((np.array([0]), f[::2])))
     return ((10**log10_A)**2 / 12.0 / np.pi**2 *
-            const.fyr**(gamma-3) * f**(-gamma))
+            const.fyr**(gamma-3) * f**(-gamma) * np.repeat(df, 2))
 
 
 @signal_base.function
 def turnover(f, log10_A=-15, gamma=4.33, lf0=-8.5, kappa=10/3, beta=0.5):
+    df = np.diff(np.concatenate((np.array([0]), f[::2])))
     hcf = (10**log10_A * (f / const.fyr) ** ((3-gamma) / 2) /
            (1 + (10**lf0 / f) ** kappa) ** beta)
-    return hcf**2/12/np.pi**2/f**3
+    return hcf**2/12/np.pi**2/f**3*np.repeat(df, 2)
 
 
 @signal_base.function

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-numpy==1.12.0
-scipy==0.18.1
-ephem==3.7.6.0
-Cython==0.25.2
+numpy>=1.12.0
+scipy>=0.18.1
+ephem>=3.7.6.0
+Cython>=0.25.2
 scikit-sparse>=0.4.2
 git+https://github.com/nanograv/PINT.git
-jplephem==2.6
+jplephem>=2.6

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,7 +8,7 @@ coverage>=4.3.4
 Sphinx>=1.5.2
 cryptography>=1.7.2
 PyYAML>=3.12
-pytest==3.0.6
+pytest>=3.0.6
 sphinx-rtd-theme>=0.1.9
 pytest-cov>=2.4.0
 coveralls>=1.1

--- a/tests/test_gp_signals.py
+++ b/tests/test_gp_signals.py
@@ -27,7 +27,8 @@ def create_quant_matrix(toas, dt=1):
 
     U, _ = utils.create_quantization_matrix(toas, dt=dt, nmin=1)
     avetoas = np.array([toas[idx.astype(bool)].mean() for idx in U.T])
-    return U, avetoas
+    # return value slightly different than 1 to get around ECORR columns
+    return U*1.0000001, avetoas
 
 @signal_base.function
 def se_kernel(etoas, log10_sigma=-7, log10_lam=np.log10(30*86400)):
@@ -530,16 +531,27 @@ class TestGPSignals(unittest.TestCase):
         pl = utils.powerlaw(log10_A=parameter.Uniform(-18,-12),
                             gamma=parameter.Uniform(1,7))
         rn = gs.FourierBasisGP(spectrum=pl, components=30)
+
+        log10_sigma = parameter.Uniform(-10, -5)
+        log10_lam = parameter.Uniform(np.log10(86400), np.log10(1500*86400))
+        basis = create_quant_matrix(dt=7*86400)
+        prior = se_kernel(log10_sigma=log10_sigma, log10_lam=log10_lam)
+        se = gs.BasisGP(prior, basis, name='se')
+
         ts = gs.TimingModel()
-        s = ec + rn + ts
+
+        s = ec + rn + ts + se
         m = s(self.psr)
 
         # parameters
         ecorr = -6.4
         log10_A, gamma = -14.5, 4.33
+        log10_lam, log10_sigma = 7.4, -6.4
         params = {'B1855+09_log10_ecorr': ecorr,
                   'B1855+09_log10_A': log10_A,
-                  'B1855+09_gamma': gamma}
+                  'B1855+09_gamma': gamma,
+                  'B1855+09_se_log10_lam': log10_lam,
+                  'B1855+09_se_log10_sigma': log10_sigma}
 
         # combined basis matrix
         U = utils.create_quantization_matrix(self.psr.toas)[0]
@@ -548,25 +560,29 @@ class TestGPSignals(unittest.TestCase):
         M /= norm
         F, f2 = utils.createfourierdesignmatrix_red(
             self.psr.toas, nmodes=30)
-        T = np.hstack((U, F, M))
+        U2, avetoas = create_quant_matrix(self.psr.toas, dt=7*86400)
+        T = np.hstack((U, F, M, U2))
 
         # combined prior vector
         jvec = 10**(2*ecorr) * np.ones(U.shape[1])
         phim = np.ones(self.psr.Mmat.shape[1]) * 1e40
         phi = utils.powerlaw(f2, log10_A=log10_A, gamma=gamma)
+        K = se_kernel(avetoas, log10_lam=log10_lam, log10_sigma=log10_sigma)
         phivec = np.concatenate((jvec, phi, phim))
+        phi = sl.block_diag(np.diag(phivec), K)
+        phiinv = np.linalg.inv(phi)
 
         # basis matrix test
         msg = 'Basis matrix incorrect for combined signal.'
         assert np.allclose(T, m.get_basis(params)), msg
 
-        # Jvec test
-        msg = 'Prior vector incorrect for combined signal.'
-        assert np.all(m.get_phi(params) == phivec), msg
+        # Kernal test
+        msg = 'Prior matrix incorrect for combined signal.'
+        assert np.allclose(m.get_phi(params), phi), msg
 
-        # inverse Jvec test
-        msg = 'Prior vector inverse incorrect for combined signal.'
-        assert np.all(m.get_phiinv(params) == 1/phivec), msg
+        # inverse Kernel test
+        msg = 'Prior matrix inverse incorrect for combined signal.'
+        assert np.allclose(m.get_phiinv(params), phiinv), msg
 
         # test shape
         msg = 'Basis matrix shape incorrect size for combined signal.'

--- a/tests/test_gp_signals.py
+++ b/tests/test_gp_signals.py
@@ -22,6 +22,7 @@ import enterprise.signals.gp_signals as gs
 from enterprise.signals import signal_base
 from enterprise.signals import utils
 
+
 @signal_base.function
 def create_quant_matrix(toas, dt=1):
 
@@ -30,11 +31,13 @@ def create_quant_matrix(toas, dt=1):
     # return value slightly different than 1 to get around ECORR columns
     return U*1.0000001, avetoas
 
+
 @signal_base.function
 def se_kernel(etoas, log10_sigma=-7, log10_lam=np.log10(30*86400)):
     tm = np.abs(etoas[None, :] - etoas[:, None])
     d = np.eye(tm.shape[0]) * 10**(2*(log10_sigma-1.5))
     return 10**(2*log10_sigma) * np.exp(-tm**2/2/10**(2*log10_lam)) + d
+
 
 class TestGPSignals(unittest.TestCase):
 
@@ -136,8 +139,8 @@ class TestGPSignals(unittest.TestCase):
 
         # parameters
         log10_lam, log10_sigma = 7.4, -6.4
-        params =  {'B1855+09_se_log10_lam': log10_lam,
-                   'B1855+09_se_log10_sigma': log10_sigma}
+        params = {'B1855+09_se_log10_lam': log10_lam,
+                  'B1855+09_se_log10_sigma': log10_sigma}
 
         # basis check
         U, avetoas = create_quant_matrix(self.psr.toas, dt=7*86400)
@@ -209,7 +212,6 @@ class TestGPSignals(unittest.TestCase):
         # inverse spectrum test
         msg = 'Kernel inverse incorrect for backend signal.'
         assert np.allclose(sem.get_phiinv(params), Kinv), msg
-
 
     def test_fourier_red_noise(self):
         """Test that red noise signal returns correct values."""

--- a/tests/test_gp_signals.py
+++ b/tests/test_gp_signals.py
@@ -129,7 +129,7 @@ class TestGPSignals(unittest.TestCase):
         assert np.allclose(F, rnm.get_basis(params)), msg
 
         # spectrum test
-        phi = utils.powerlaw(f2, log10_A=log10_A, gamma=gamma) * f2[0]
+        phi = utils.powerlaw(f2, log10_A=log10_A, gamma=gamma)
         msg = 'Spectrum incorrect for GP Fourier signal.'
         assert np.all(rnm.get_phi(params) == phi), msg
 
@@ -171,7 +171,7 @@ class TestGPSignals(unittest.TestCase):
                 self.psr.toas[mask], 30)
             Fmats.append(F)
             fs.append(f)
-            phis.append(utils.powerlaw(f, log10_As[ct], gammas[ct])*f[0])
+            phis.append(utils.powerlaw(f, log10_As[ct], gammas[ct]))
 
         nf = sum(F.shape[1] for F in Fmats)
         F = np.zeros((len(self.psr.toas), nf))
@@ -233,8 +233,8 @@ class TestGPSignals(unittest.TestCase):
                 self.psr.toas, nmodes=nf2, Tspan=T2)
 
             # test power spectrum
-            p1 = utils.powerlaw(f1, log10_A, gamma) * f1[0]
-            p2 = utils.powerlaw(f2, log10_Ac, gammac) * f2[0]
+            p1 = utils.powerlaw(f1, log10_A, gamma)
+            p2 = utils.powerlaw(f2, log10_Ac, gammac)
             if T1 == T2:
                 nf = max(2*nf1, 2*nf2)
                 phi = np.zeros(nf)
@@ -302,14 +302,14 @@ class TestGPSignals(unittest.TestCase):
             Fmats, fs, phis = [], [], []
             F2, f2 = utils.createfourierdesignmatrix_red(
                 self.psr.toas, nf2, Tspan=T2)
-            p2 = utils.powerlaw(f2, log10_Ac, gammac)*f2[0]
+            p2 = utils.powerlaw(f2, log10_Ac, gammac)
             for ct, flag in enumerate(np.unique(bflags)):
                 mask = bflags == flag
                 F1, f1 = utils.createfourierdesignmatrix_red(
                     self.psr.toas[mask], nf1, Tspan=T1)
                 Fmats.append(F1)
                 fs.append(f1)
-                phis.append(utils.powerlaw(f1, log10_As[ct], gammas[ct])*f1[0])
+                phis.append(utils.powerlaw(f1, log10_As[ct], gammas[ct]))
 
             Fmats.append(F2)
             phis.append(p2)
@@ -399,9 +399,9 @@ class TestGPSignals(unittest.TestCase):
             log10_Q=log10_Q, t0=t0)
         F = np.hstack((Fenv, Fred))
         phi_env = utils.powerlaw(f2_env, log10_A=log10_A_env,
-                                 gamma=gamma_env) * f2_env[0]
+                                 gamma=gamma_env)
         phi_red = utils.powerlaw(f2_red, log10_A=log10_A,
-                                 gamma=gamma) * f2_red[0]
+                                 gamma=gamma)
         phi = np.concatenate((phi_env, phi_red))
 
         # basis matrix test
@@ -452,7 +452,7 @@ class TestGPSignals(unittest.TestCase):
         # combined prior vector
         jvec = 10**(2*ecorr) * np.ones(U.shape[1])
         phim = np.ones(self.psr.Mmat.shape[1]) * 1e40
-        phi = utils.powerlaw(f2, log10_A=log10_A, gamma=gamma) * f2[0]
+        phi = utils.powerlaw(f2, log10_A=log10_A, gamma=gamma)
         phivec = np.concatenate((jvec, phi, phim))
 
         # basis matrix test

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -23,6 +23,7 @@ from enterprise.signals import white_signals
 from enterprise.signals import gp_signals
 from enterprise.signals import utils
 
+
 @signal_base.function
 def create_quant_matrix(toas, dt=1):
 
@@ -30,6 +31,7 @@ def create_quant_matrix(toas, dt=1):
     avetoas = np.array([toas[idx.astype(bool)].mean() for idx in U.T])
     # return value slightly different than 1 to get around ECORR columns
     return U*1.0000001, avetoas
+
 
 @signal_base.function
 def se_kernel(etoas, log10_sigma=-7, log10_lam=np.log10(30*86400)):

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -23,6 +23,20 @@ from enterprise.signals import white_signals
 from enterprise.signals import gp_signals
 from enterprise.signals import utils
 
+@signal_base.function
+def create_quant_matrix(toas, dt=1):
+
+    U, _ = utils.create_quantization_matrix(toas, dt=dt, nmin=1)
+    avetoas = np.array([toas[idx.astype(bool)].mean() for idx in U.T])
+    # return value slightly different than 1 to get around ECORR columns
+    return U*1.0000001, avetoas
+
+@signal_base.function
+def se_kernel(etoas, log10_sigma=-7, log10_lam=np.log10(30*86400)):
+    tm = np.abs(etoas[None, :] - etoas[:, None])
+    d = np.eye(tm.shape[0]) * 10**(2*(log10_sigma-1.5))
+    return 10**(2*log10_sigma) * np.exp(-tm**2/2/10**(2*log10_lam)) + d
+
 
 def get_noise_from_pal2(noisefile):
     psrname = noisefile.split('/')[-1].split('_noise.txt')[0]
@@ -111,18 +125,32 @@ class TestLikelihood(unittest.TestCase):
 
         tm = gp_signals.TimingModel()
 
+        log10_sigma = parameter.Uniform(-10, -5)
+        log10_lam = parameter.Uniform(np.log10(86400), np.log10(1500*86400))
+        basis = create_quant_matrix(dt=7*86400)
+        prior = se_kernel(log10_sigma=log10_sigma, log10_lam=log10_lam)
+        se = gp_signals.BasisGP(prior, basis, name='se')
+
         if inc_corr:
-            s = ef + eq + ec + rn + crn + tm
+            s = ef + eq + ec + rn + crn + tm + se
         else:
-            s = ef + eq + ec + rn + tm
+            s = ef + eq + ec + rn + tm + se
 
         pta = signal_base.PTA([s(psr) for psr in psrs])
 
         # set parameters
         pta.set_default_params(params)
 
+        # SE kernel parameters
+        log10_sigmas, log10_lams = [-7.0, -6.5], [7.0, 6.5]
+        params.update({'B1855+09_se_log10_lam': log10_lams[0],
+                       'B1855+09_se_log10_sigma': log10_sigmas[0],
+                       'J1909-3744_se_log10_lam': log10_lams[1],
+                       'J1909-3744_se_log10_sigma': log10_sigmas[1]})
+
         # get parameters
         efacs, equads, ecorrs, log10_A, gamma = [], [], [], [], []
+        lsig, llam = [], []
         for pname in [p.name for p in psrs]:
             efacs.append([params[key] for key in sorted(params.keys())
                           if 'efac' in key and pname in key])
@@ -132,6 +160,8 @@ class TestLikelihood(unittest.TestCase):
                            if 'ecorr' in key and pname in key])
             log10_A.append(params['{}_log10_A'.format(pname)])
             gamma.append(params['{}_gamma'.format(pname)])
+            lsig.append(params['{}_se_log10_sigma'.format(pname)])
+            llam.append(params['{}_se_log10_lam'.format(pname)])
         GW_gamma = 4.33
         GW_log10_A = -15.0
 
@@ -176,7 +206,8 @@ class TestLikelihood(unittest.TestCase):
             Mmat = psr.Mmat.copy()
             norm = np.sqrt(np.sum(Mmat**2, axis=0))
             Mmat /= norm
-            T = np.hstack((F, Mmat))
+            U2, avetoas = create_quant_matrix(psr.toas, dt=7*86400)
+            T = np.hstack((F, Mmat, U2))
             Ts.append(T)
             phi = utils.powerlaw(f2, log10_A=log10_A[ii],
                                  gamma=gamma[ii])
@@ -185,8 +216,12 @@ class TestLikelihood(unittest.TestCase):
                                        gamma=GW_gamma)
             else:
                 phigw = np.zeros(40)
-            phis.append(np.concatenate(
-                (phi+phigw, np.ones(Mmat.shape[1])*1e40)))
+            K = se_kernel(avetoas, log10_sigma=log10_sigmas[ii],
+                          log10_lam=log10_lams[ii])
+            k = np.diag(np.concatenate((phi+phigw,
+                                        np.ones(Mmat.shape[1])*1e40)))
+            k = sl.block_diag(k, K)
+            phis.append(k)
 
         # manually compute loglike
         loglike = 0
@@ -198,7 +233,7 @@ class TestLikelihood(unittest.TestCase):
                 cfs[ct], psr.residuals)) + logdets[ct])
 
         TNr = np.concatenate(TNrs)
-        phi = np.diag(np.concatenate(phis))
+        phi = sl.block_diag(*phis)
 
         if inc_corr:
             hd = utils.hd_orf(psrs[0].pos, psrs[1].pos)

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -179,10 +179,10 @@ class TestLikelihood(unittest.TestCase):
             T = np.hstack((F, Mmat))
             Ts.append(T)
             phi = utils.powerlaw(f2, log10_A=log10_A[ii],
-                                 gamma=gamma[ii]) * f2[0]
+                                 gamma=gamma[ii])
             if inc_corr:
                 phigw = utils.powerlaw(f2, log10_A=GW_log10_A,
-                                       gamma=GW_gamma) * f2[0]
+                                       gamma=GW_gamma)
             else:
                 phigw = np.zeros(40)
             phis.append(np.concatenate(

--- a/tests/test_pta.py
+++ b/tests/test_pta.py
@@ -66,18 +66,6 @@ class TestPTASignals(unittest.TestCase):
     def setUpClass(cls):
         """Setup the Pulsar object."""
 
-        #if os.path.isfile(datadir + '/B1855+09.pkl') and \
-        #        os.path.isfile(datadir + '/J1909-3744.pkl'):
-        #    self.psrs = [pickle.load(open(datadir + '/B1855+09.pkl','r')),
-        #                 pickle.load(open(datadir + '/J1909-3744.pkl','r'))]
-        #else:
-        #    self.psrs = [Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
-        #                        datadir + '/B1855+09_NANOGrav_9yv1.tim'),
-        #                 Pulsar(datadir + '/J1909-3744_NANOGrav_9yv1.gls.par',
-        #                        datadir + '/J1909-3744_NANOGrav_9yv1.tim')]
-#
-        #    for psr in self.psrs:
-        #        psr.to_pickle(datadir)
         cls.psrs = [Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
                            datadir + '/B1855+09_NANOGrav_9yv1.tim'),
                     Pulsar(datadir + '/J1909-3744_NANOGrav_9yv1.gls.par',
@@ -124,14 +112,14 @@ class TestPTASignals(unittest.TestCase):
         phidiag = np.zeros(nftot)
         phit = np.zeros((nftot, nftot))
 
-        phidiag[:60] = utils.powerlaw(f1, lA1, gamma1) * f1[0]
-        phidiag[:60] += utils.powerlaw(f1, lAc, gammac) * f1[0]
-        phidiag[60:] = utils.powerlaw(f2, lA2, gamma2) * f2[0]
-        phidiag[60:] += utils.powerlaw(f2, lAc, gammac) * f2[0]
+        phidiag[:60] = utils.powerlaw(f1, lA1, gamma1)
+        phidiag[:60] += utils.powerlaw(f1, lAc, gammac)
+        phidiag[60:] = utils.powerlaw(f2, lA2, gamma2)
+        phidiag[60:] += utils.powerlaw(f2, lAc, gammac)
 
         phit[np.diag_indices(nftot)] = phidiag
         orf = hd_orf_generic(self.psrs[0].pos, self.psrs[1].pos, a=a, b=b, c=c)
-        spec = utils.powerlaw(f1, log10_A=lAc, gamma=gammac) * f1[0]
+        spec = utils.powerlaw(f1, log10_A=lAc, gamma=gammac)
         phit[:60, 60:] = np.diag(orf*spec)
         phit[60:, :60] = phit[:60, 60:]
 
@@ -321,19 +309,19 @@ class TestPTASignals(unittest.TestCase):
         phidiag = np.zeros(nftot)
         phit = np.zeros((nftot, nftot))
 
-        phidiag[:4] = utils.powerlaw(f1, lA1, gamma1) * f1[0]
-        phidiag[:2] += utils.powerlaw(fc, lAc, gammac) * fc[0]
-        phidiag[4:] = utils.powerlaw(f2, lA2, gamma2) * f2[0]
-        phidiag[4:6] += utils.powerlaw(fc, lAc, gammac) * fc[0]
+        phidiag[:4] = utils.powerlaw(f1, lA1, gamma1)
+        phidiag[:2] += utils.powerlaw(fc, lAc, gammac)
+        phidiag[4:] = utils.powerlaw(f2, lA2, gamma2)
+        phidiag[4:6] += utils.powerlaw(fc, lAc, gammac)
 
         phit[np.diag_indices(nftot)] = phidiag
 
         phit[:2, 4:6] = np.diag(hd_powerlaw(fc, self.psrs[0].pos,
                                             self.psrs[1].pos, lAc,
-                                            gammac) * fc[0])
+                                            gammac))
         phit[4:6, :2] = np.diag(hd_powerlaw(fc, self.psrs[0].pos,
                                             self.psrs[1].pos, lAc,
-                                            gammac) * fc[0])
+                                            gammac))
 
         msg = '{} {}'.format(np.diag(phi), np.diag(phit))
         assert np.allclose(phi, phit, rtol=1e-15, atol=1e-17), msg

--- a/tests/test_set_parameter.py
+++ b/tests/test_set_parameter.py
@@ -174,7 +174,7 @@ class TestSetParameters(unittest.TestCase):
             self.psrs[0].toas, nmodes=20)
 
         # spectrum test
-        phi = utils.powerlaw(f2, log10_A=log10_A, gamma=gamma) 
+        phi = utils.powerlaw(f2, log10_A=log10_A, gamma=gamma)
         msg = 'Spectrum incorrect for GP Fourier signal.'
         assert np.all(m.get_phi(params) == phi), msg
 

--- a/tests/test_set_parameter.py
+++ b/tests/test_set_parameter.py
@@ -174,7 +174,7 @@ class TestSetParameters(unittest.TestCase):
             self.psrs[0].toas, nmodes=20)
 
         # spectrum test
-        phi = utils.powerlaw(f2, log10_A=log10_A, gamma=gamma) * f2[0]
+        phi = utils.powerlaw(f2, log10_A=log10_A, gamma=gamma) 
         msg = 'Spectrum incorrect for GP Fourier signal.'
         assert np.all(m.get_phi(params) == phi), msg
 
@@ -263,7 +263,7 @@ class TestSetParameters(unittest.TestCase):
 
             F, f2 = utils.createfourierdesignmatrix_red(psr.toas, nmodes=20)
             phi = utils.powerlaw(f2, log10_A=log10_A[ii],
-                                 gamma=gamma[ii]) * f2[0]
+                                 gamma=gamma[ii])
             phis.append(phi)
 
         # tests

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -149,4 +149,4 @@ class TestUtils(unittest.TestCase):
         msg = 'PSD calculation incorrect'
         assert np.allclose(utils.powerlaw(f, log10_A, gamma), pl), msg
         assert np.allclose(utils.turnover(f, log10_A, gamma,
-                                     lf0, kappa, beta),pt), msg
+                                          lf0, kappa, beta),pt), msg

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -141,12 +141,12 @@ class TestUtils(unittest.TestCase):
         kappa = 10/3
         beta = 0.5
         pl = ((10**log10_A)**2 / 12.0 / np.pi**2 *
-              const.fyr**(gamma-3) * f**(-gamma))
+              const.fyr**(gamma-3) * f**(-gamma)*f[0])
         hcf = (10**log10_A * (f / const.fyr) ** ((3-gamma) / 2) /
                (1 + (10**lf0 / f) ** kappa) ** beta)
-        pt = hcf**2/12/np.pi**2/f**3
+        pt = hcf**2/12/np.pi**2/f**3 * f[0]
 
         msg = 'PSD calculation incorrect'
-        assert np.all(utils.powerlaw(f, log10_A, gamma) == pl), msg
-        assert np.all(utils.turnover(f, log10_A, gamma,
-                                     lf0, kappa, beta) == pt), msg
+        assert np.allclose(utils.powerlaw(f, log10_A, gamma), pl), msg
+        assert np.allclose(utils.turnover(f, log10_A, gamma,
+                                     lf0, kappa, beta),pt), msg

--- a/tests/test_vector_parameter.py
+++ b/tests/test_vector_parameter.py
@@ -22,7 +22,7 @@ from enterprise.signals import signal_base
 
 @signal_base.function
 def free_spectrum(f, log10_rho=None):
-    return np.repeat(10**log10_rho,2) 
+    return np.repeat(10**log10_rho,2)
 
 
 class TestVectorParameter(unittest.TestCase):

--- a/tests/test_vector_parameter.py
+++ b/tests/test_vector_parameter.py
@@ -22,7 +22,7 @@ from enterprise.signals import signal_base
 
 @signal_base.function
 def free_spectrum(f, log10_rho=None):
-    return np.repeat(10**log10_rho,2) / f[0]
+    return np.repeat(10**log10_rho,2) 
 
 
 class TestVectorParameter(unittest.TestCase):


### PR DESCRIPTION
This PR implements 2-D GP kernels which solves some problems mentioned in Issue #93. Previously all gaussian process kernels (or priors, think diagonal phi matrix) were assumed to be 1-d (i.e. diagonal). These new commits don't change the API at all so all of the old GP modeling stuff still works the same, but you can now do something like the following to implement a Squared-Exponential Kernel in the daily averaged basis (averaging over 7 days)
```python
@signal_base.function
def create_quant_matrix(toas, dt=1):

    U, _ = utils.create_quantization_matrix(toas, dt=dt, nmin=1)
    avetoas = np.array([toas[idx.astype(bool)].mean() for idx in U.T])
    return U, avetoas

@signal_base.function
def se_kernel(avetoas, log10_sigma=-7, log10_lam=np.log10(30*86400)):
    tm = np.abs(avetoas[None, :] - avetoas[:, None])

    # add to diagonal to make stable
    d = np.eye(tm.shape[0]) * 10**(2*(log10_sigma-1.5))
    return 10**(2*log10_sigma) * np.exp(-tm**2/2/10**(2*log10_lam)) + d

# define signal
log10_sigma = parameter.Uniform(-10, -5)
log10_lam = parameter.Uniform(np.log10(86400), np.log10(1500*86400))
basis = create_quant_matrix(dt=7*86400)
prior = se_kernel(log10_sigma=log10_sigma, log10_lam=log10_lam)
se = gp_signals.BasisGP(prior, basis, name='se')
```

I have written new tests for this and it all seems to work fine with and without spatial correlations except when using the "cliques" method for spatial correlations. @vallis, can you maybe take a look at this?

One other thing that I changed here is how the PSDs are handled which I think clears up Issue #30. Before the "prior" for PSDs, `powerlaw` for instance, would return something in s^3 but the Kernel is expected to be a variance. We would get around this by multiplying by f[0] (same as 1/Tspan) when we constructed the actual variance but this is not general because it wouldn't work for anything but linear frequency spacing and also I had to use this same formalism for all other Basis type signals which means I was multiplying the variance (ECORR) for instance with ones. 

So the new formalism assumes that the "priorFunction in `BasisGP` actually returns a variance. For all other signals this was already the case but now I have changed the PSD definitions to include the df piece so now when they read in the frequency, f, it computes df by `df=np.diff(np.concatenate(np.array([0]), f))`. This way it is correct for whatever type of frequency spacing we have!

Also, as you can see form the commit tags, I'm having problems with Travis again :(.