### PR TITLE
Implementing BWM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr htmlcov/
 
 lint: ## check style with flake8
-	flake8 --ignore=E265,E226,E231,E731 enterprise tests
+	flake8 --ignore=E265,E226,E231,E731,E722 enterprise tests
 
 test: ## run tests quickly with the default Python
 

--- a/enterprise/signals/utils.py
+++ b/enterprise/signals/utils.py
@@ -592,12 +592,11 @@ def calculate_splus_scross(nmax, mc, dl, h0, F, e,
     return np.sum(splus_n, axis=1), np.sum(scross_n, axis=1)
 
 
-def create_gw_antenna_pattern(theta, phi, gwtheta, gwphi):
+def create_gw_antenna_pattern(pos, gwtheta, gwphi):
     """
     Function to create pulsar antenna pattern functions as defined
     in Ellis, Siemens, and Creighton (2012).
-    :param theta: Polar angle of pulsar location.
-    :param phi: Azimuthal angle of pulsar location.
+    :param pos: Unit vector from Earth to pulsar
     :param gwtheta: GW polar angle in radians
     :param gwphi: GW azimuthal angle in radians
 
@@ -616,20 +615,16 @@ def create_gw_antenna_pattern(theta, phi, gwtheta, gwphi):
                       -np.sin(gwtheta)*np.sin(gwphi),
                       -np.cos(gwtheta)])
 
-    phat = np.array([np.sin(theta)*np.cos(phi),
-                     np.sin(theta)*np.sin(phi),
-                     np.cos(theta)])
-
-    fplus = (0.5 * (np.dot(m, phat)**2 - np.dot(n, phat)**2) /
-             (1+np.dot(omhat, phat)))
-    fcross = (np.dot(m, phat)*np.dot(n, phat)) / (1 + np.dot(omhat, phat))
-    cosMu = -np.dot(omhat, phat)
+    fplus = (0.5 * (np.dot(m, pos)**2 - np.dot(n, pos)**2) /
+             (1+np.dot(omhat, pos)))
+    fcross = (np.dot(m, pos)*np.dot(n, pos)) / (1 + np.dot(omhat, pos))
+    cosMu = -np.dot(omhat, pos)
 
     return fplus, fcross, cosMu
 
 
 @signal_base.function
-def bwm_delay(toas, theta, phi, log10_h=-14.0, cos_gwtheta=0.0, gwphi=0.0,
+def bwm_delay(toas, pos, log10_h=-14.0, cos_gwtheta=0.0, gwphi=0.0,
               gwpol=0.0, t0=55000):
     """
     Function that calculates the earth-term gravitational-wave
@@ -639,8 +634,7 @@ def bwm_delay(toas, theta, phi, log10_h=-14.0, cos_gwtheta=0.0, gwphi=0.0,
     Continuous Wave and Anisotropy papers.
 
     :param toas: Time-of-arrival measurements [s]
-    :param theta: Polar angle of pulsar sky location
-    :param phi: Azimuthal angle of pulsar sky location
+    :param pos: Unit vector from Earth to pulsar
     :param log10_h: log10 of GW strain
     :param cos_gwtheta: Cosine of GW polar angle
     :param gwphi: GW azimuthal polar angle [rad]
@@ -656,7 +650,7 @@ def bwm_delay(toas, theta, phi, log10_h=-14.0, cos_gwtheta=0.0, gwphi=0.0,
     t0 *= const.day
 
     # antenna patterns
-    fp, fc, _ = create_gw_antenna_pattern(theta, phi, gwtheta, gwphi)
+    fp, fc, _ = create_gw_antenna_pattern(pos, gwtheta, gwphi)
 
     # combined polarization
     pol = np.cos(2*gwpol)*fp + np.sin(2*gwpol)*fc

--- a/tests/test_deterministic_signals.py
+++ b/tests/test_deterministic_signals.py
@@ -38,6 +38,35 @@ class TestDeterministicSignals(unittest.TestCase):
         cls.psr = Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
                          datadir + '/B1855+09_NANOGrav_9yv1.tim')
 
+    def test_bwm(self):
+        """Test BWM waveform."""
+        log10_h = parameter.Uniform(-20, -11)('bwm_log10_h')
+        cos_gwtheta = parameter.Uniform(-1, 1)('bwm_cos_gwtheta')
+        gwphi = parameter.Uniform(0, 2*np.pi)('bwm_gwphi')
+        gwpol = parameter.Uniform(0, np.pi)('bwm_gwpol')
+        t0 = parameter.Uniform(53000, 57000)('bwm_t0')
+        bwm_wf = utils.bwm_delay(log10_h=log10_h, cos_gwtheta=cos_gwtheta,
+                                 gwphi=gwphi, gwpol=gwpol, t0=t0)
+        bwm = deterministic_signals.Deterministic(bwm_wf)
+        m = bwm(self.psr)
+
+        # true parameters
+        log10_h = -14
+        cos_gwtheta = 0.5
+        gwphi = 0.5
+        gwpol = 0.0
+        t0 = 55000
+        params = {'bwm_log10_h': log10_h, 'bwm_cos_gwtheta': cos_gwtheta,
+                  'bwm_gwphi': gwphi, 'bwm_gwpol': gwpol, 'bwm_t0': t0}
+
+        d1 = utils.bwm_delay(self.psr.toas, self.psr.pos, log10_h=log10_h,
+                             cos_gwtheta=cos_gwtheta, gwphi=gwphi,
+                             gwpol=gwpol, t0=t0)
+
+        # test
+        msg = 'BWM Delay incorrect'
+        assert np.all(m.get_delay(params) == d1), msg
+
     def test_delay(self):
         """Test deterministic signal no selection."""
         # set up signal and parameters

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -97,8 +97,8 @@ class TestUtils(unittest.TestCase):
         """Check fplus, fcross generation."""
         gwtheta = 1.4
         gwphi = 2.7
-        fplus, fcross = utils.fplus_fcross(self.psr.theta, self.psr.phi,
-                                           gwtheta, gwphi)
+        fplus, fcross, _ = utils.create_gw_antenna_pattern(self.psr.pos,
+                                                           gwtheta, gwphi)
 
         msg1 = 'Fplus value incorrect'
         msg2 = 'Fcross value incorrect'


### PR DESCRIPTION
Implemented BWM function that can take antenna pattern function as argument (used GW by default) so that different correlations can be tested. The signal is easily set up with 
```python
log10_h = parameter.Uniform(-20, -11)('bwm_log10_h')
cos_gwtheta = parameter.Uniform(-1, 1)('bwm_cos_gwtheta')
gwphi = parameter.Uniform(0, 2*np.pi)('bwm_gwphi')
gwpol = parameter.Uniform(0, np.pi)('bwm_gwpol')
t0 = parameter.Uniform(tmin/86400, tmax/86400)('bwm_t0')
bwm_wf = utils.bwm_delay(log10_h=log10_h, cos_gwtheta=cos_gwtheta, 
                         gwphi=gwphi, gwpol=gwpol, t0=t0)
bwm = deterministic_signals.Deterministic(bwm_wf)
```