### PR TITLE
Adding backup function for cholesky if no sksparse

### DIFF
--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -30,12 +30,14 @@ logger = logging.getLogger(__name__)
 try:
     from sksparse.cholmod import cholesky
 except ImportError:
-    msg = 'No sksparse library. Using numpy instead!'
+    msg = 'No sksparse library. Using scipy instead!'
     logger.warning(msg)
 
     class cholesky(object):
 
         def __init__(self, x):
+            if sps.issparse(x):
+                x = x.toarray()
             self.cf = sl.cho_factor(x)
 
         def __call__(self, other):

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -17,7 +17,6 @@ import numpy as np
 import scipy.sparse as sps
 import scipy.linalg as sl
 
-from sksparse.cholmod import cholesky
 
 from enterprise.signals.parameter import ConstantParameter, Parameter
 from enterprise.signals.selections import selection_func
@@ -26,6 +25,27 @@ import logging
 logging.basicConfig(format='%(levelname)s: %(name)s: %(message)s',
                     level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+
+try:
+    from sksparse.cholmod import cholesky
+except ImportError:
+    msg = 'No sksparse library. Using numpy instead!'
+    logger.warning(msg)
+
+    class cholesky(object):
+
+        def __init__(self, x):
+            self.cf = sl.cho_factor(x)
+
+        def __call__(self, other):
+            return sl.cho_solve(self.cf, other)
+
+        def logdet(self):
+            return np.sum(2 * np.log(np.diag(self.cf[0])))
+
+        def inv(self):
+            return sl.cho_solve(self.cf, np.eye(len(self.cf[0])))
 
 
 class MetaSignal(type):


### PR DESCRIPTION
There is no reason for the code to crash if one doesn't have `cholmod` since it is only used in special cases. I've added a try-except statement to the import and then added a stub class that just uses `scipy` instead. That way the code will still run through the sparse stuff, albeit much slower. A warning is printed if this is the case.