### PR TITLE
Add svd_design matrix option

### DIFF
--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -4,4 +4,4 @@ from __future__ import (absolute_import, division,
 
 __author__ = """Justin A. Ellis"""
 __email__ = 'justin.ellis18@gmail.com'
-__version__ = '1.1.0'
+__version__ = '1.2.0'

--- a/enterprise/signals/gp_signals.py
+++ b/enterprise/signals/gp_signals.py
@@ -109,41 +109,17 @@ def FourierBasisGP(spectrum, components=20,
     return FourierBasisGP
 
 
-def TimingModel(name='linear_timing_model'):
+def TimingModel(name='linear_timing_model', use_svd=False):
     """Class factory for marginalized linear timing model signals."""
 
-    class TimingModel(base.Signal):
+    basis = utils.svd_tm_basis() if use_svd else utils.normed_tm_basis()
+    prior = utils.tm_prior()
+    BaseClass = BasisGP(prior, basis, name=name)
+
+    class TimingModel(BaseClass):
         signal_type = 'basis'
         signal_name = 'linear timing model'
-        signal_id = name
-
-        def __init__(self, psr):
-            super(TimingModel, self).__init__(psr)
-            self.name = self.psrname + '_' + self.signal_id
-            self._params = {}
-
-            self._F = psr.Mmat.copy()
-
-            norm = np.sqrt(np.sum(self._F**2, axis=0))
-            self._F /= norm
-
-        def get_basis(self, params=None):
-            return self._F
-
-        def get_phi(self, params=None):
-            return np.ones(self._F.shape[1])*1e40
-
-        def get_phiinv(self, params=None):
-            return 1 / self.get_phi(params)
-
-        @property
-        def basis_shape(self):
-            return self._F.shape
-
-        #TODO: this is somewhat of a hack until we get this class more general
-        @property
-        def basis_params(self):
-            return []
+        signal_id = name + '_svd' if use_svd else name
 
     return TimingModel
 

--- a/enterprise/signals/utils.py
+++ b/enterprise/signals/utils.py
@@ -788,6 +788,23 @@ def monopole_orf(pos1, pos2):
         return 1.0
 
 
+@signal_base.function
+def normed_tm_basis(Mmat):
+    norm = np.sqrt(np.sum(Mmat**2, axis=0))
+    return Mmat / norm, np.ones_like(Mmat.shape[1])
+
+
+@signal_base.function
+def svd_tm_basis(Mmat):
+    u, s, v = np.linalg.svd(Mmat, full_matrices=False)
+    return u, np.ones_like(s)
+
+
+@signal_base.function
+def tm_prior(weights):
+    return weights * 1e40
+
+
 # Physical ephemeris model utility functions
 
 t_offset = 55197.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.0
+current_version = 1.2.0
 commit = False
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ test_requirements = []
 
 setup(
     name='enterprise',
-    version='1.1.0',
+    version='1.2.0',
     description="ENTERPRISE (Enhanced Numerical Toolbox Enabling a Robust PulsaR Inference SuitE)",
     long_description=readme + '\n\n' + history,
     author="Justin A. Ellis",

--- a/tests/test_gp_signals.py
+++ b/tests/test_gp_signals.py
@@ -450,21 +450,22 @@ class TestGPSignals(unittest.TestCase):
         M = self.psr.Mmat.copy()
         norm = np.sqrt(np.sum(M**2, axis=0))
         M /= norm
+        params = {}
         msg = 'M matrix incorrect for Timing Model signal.'
-        assert np.allclose(M, tm.get_basis()), msg
+        assert np.allclose(M, tm.get_basis(params)), msg
 
         # Jvec test
         phi = np.ones(self.psr.Mmat.shape[1]) * 1e40
         msg = 'Prior vector incorrect for Timing Model signal.'
-        assert np.all(tm.get_phi() == phi), msg
+        assert np.all(tm.get_phi(params) == phi), msg
 
         # inverse Jvec test
         msg = 'Prior vector inverse incorrect for Timing Model signal.'
-        assert np.all(tm.get_phiinv() == 1/phi), msg
+        assert np.all(tm.get_phiinv(params) == 1/phi), msg
 
         # test shape
         msg = 'M matrix shape incorrect'
-        assert tm.get_basis().shape == self.psr.Mmat.shape, msg
+        assert tm.get_basis(params).shape == self.psr.Mmat.shape, msg
 
     def test_gp_parameter(self):
         """Test GP basis model with parameterized basis."""


### PR DESCRIPTION
The timing model now has the option to use an SVD decomposition instead of the normal column scaling

`TimingModel(use_svd=True)`

`use_svd` is set to false by default to keep backwards compatibility.