### PR TITLE
add notebook checkpoints to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
+.ipynb_checkpoints/
 
 # PyBuilder
 target/


### PR DESCRIPTION
We shouldn't be keeping ipython notebook checkpoints in the repo.