### PR TITLE
Access DMX data from Pulsar (currently with Tempo2Pulsar only)

### DIFF
--- a/enterprise/pulsar.py
+++ b/enterprise/pulsar.py
@@ -180,6 +180,11 @@ class BasePulsar(object):
         return self._toas[self._isort]
 
     @property
+    def stoas(self):
+        """Return array of observatory TOAs in seconds."""
+        return self._stoas[self._isort]
+
+    @property
     def residuals(self):
         """Return array of residuals in seconds."""
         return self._residuals[self._isort]
@@ -203,6 +208,16 @@ class BasePulsar(object):
     def pdist(self):
         """Return tuple of pulsar distance and uncertainty in kpc."""
         return self._pdist
+
+    @property
+    def dm(self):
+        """Return DM parameter from parfile."""
+        return self._dm
+
+    @property
+    def dmx(self):
+        """Return a dictionary of DMX-parameter values and stoa ranges from parfile."""
+        return self._dmx
 
     @property
     def flags(self):
@@ -333,6 +348,7 @@ class Tempo2Pulsar(BasePulsar):
         self.name = str(t2pulsar.name)
 
         self._toas = np.double(t2pulsar.toas()) * 86400
+        self._stoas = np.double(t2pulsar.stoas) * 86400         # saving also stoas (e.g., for DMX comparisons)
         self._residuals = np.double(t2pulsar.residuals())
         self._toaerrs = np.double(t2pulsar.toaerrs) * 1e-6
         self._designmatrix = np.double(t2pulsar.designmatrix())
@@ -354,6 +370,9 @@ class Tempo2Pulsar(BasePulsar):
         self._pos = self._get_pos()
         self._planetssb = self._get_planetssb(t2pulsar)
 
+        # gather DM/DMX information if available
+        self._set_dm(t2pulsar)
+
         self._pos_t = t2pulsar.psrPos.copy()
         if 'ELONG' and 'ELAT' in np.concatenate((t2pulsar.pars(which='fit'),
                                                  t2pulsar.pars(which='set'))):
@@ -363,6 +382,23 @@ class Tempo2Pulsar(BasePulsar):
 
         if drop_t2pulsar:
             del self.t2pulsar
+
+    # gather DM/DMX information if available
+    def _set_dm(self, t2pulsar):
+        pars = t2pulsar.pars(which='set')
+
+        if 'DM' in pars:
+            self._dm = t2pulsar['DM'].val
+
+        dmx = {par: {'DMX': t2pulsar[par].val,
+                     'DMXerr': t2pulsar[par].err,
+                     'DMXR1': t2pulsar[par[:3] + 'R1' + par[3:]].val,
+                     'DMXR2': t2pulsar[par[:3] + 'R2' + par[3:]].val,
+                     'fit': par in pars}
+               for par in pars if 'DMX_' in par}
+
+        if dmx:
+            self._dmx = dmx
 
     def _get_radec(self, t2pulsar):
         if 'RAJ' in np.concatenate((t2pulsar.pars(which='fit'),

--- a/enterprise/pulsar.py
+++ b/enterprise/pulsar.py
@@ -216,7 +216,8 @@ class BasePulsar(object):
 
     @property
     def dmx(self):
-        """Return a dictionary of DMX-parameter values and stoa ranges from parfile."""
+        """Return a dictionary of DMX-parameter values
+        and stoa ranges from parfile."""
         return self._dmx
 
     @property
@@ -348,7 +349,8 @@ class Tempo2Pulsar(BasePulsar):
         self.name = str(t2pulsar.name)
 
         self._toas = np.double(t2pulsar.toas()) * 86400
-        self._stoas = np.double(t2pulsar.stoas) * 86400         # saving also stoas (e.g., for DMX comparisons)
+        # saving also stoas (e.g., for DMX comparisons)
+        self._stoas = np.double(t2pulsar.stoas) * 86400
         self._residuals = np.double(t2pulsar.residuals())
         self._toaerrs = np.double(t2pulsar.toaerrs) * 1e-6
         self._designmatrix = np.double(t2pulsar.designmatrix())

--- a/tests/test_pulsar.py
+++ b/tests/test_pulsar.py
@@ -49,6 +49,23 @@ class TestPulsar(unittest.TestCase):
         msg = 'TOA shape incorrect'
         assert self.psr.toas.shape == (4005,), msg
 
+    def test_stoas(self):
+        """Check STOA shape."""
+
+        msg = 'stoa shape incorrect'
+        assert self.psr.stoas.shape == (4005,), msg
+
+    def test_dm(self):
+        """Check DM/DMX access."""
+
+        msg = 'dm value incorrect'
+        assert self.psr.dm == np.longdouble('13.299393'), msg
+
+        msg = 'dmx struct incorrect (spotcheck)'
+        assert len(self.psr.dmx) == 72, msg
+        assert self.psr.dmx['DMX_0001']['DMX'] == np.longdouble('0.015161863'), msg
+        assert self.psr.dmx['DMX_0001']['fit'] == True, msg
+
     def test_freqs(self):
         """Check frequencies shape."""
 
@@ -120,3 +137,11 @@ class TestPulsarPint(TestPulsar):
         cls.psr = Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
                          datadir + '/B1855+09_NANOGrav_9yv1.tim',
                          ephem='DE430', timing_package='pint')
+
+    # exclude tests pending implementation of .stoas, .dm, .dmx in PintPulsar 
+
+    def test_stoas(self):
+        pass
+
+    def test_dm(self):
+        pass

--- a/tests/test_pulsar.py
+++ b/tests/test_pulsar.py
@@ -63,8 +63,9 @@ class TestPulsar(unittest.TestCase):
 
         msg = 'dmx struct incorrect (spotcheck)'
         assert len(self.psr.dmx) == 72, msg
-        assert self.psr.dmx['DMX_0001']['DMX'] == np.longdouble('0.015161863'), msg
-        assert self.psr.dmx['DMX_0001']['fit'] == True, msg
+        assert (self.psr.dmx['DMX_0001']['DMX'] ==
+                np.longdouble('0.015161863')), msg
+        assert self.psr.dmx['DMX_0001']['fit'] is True, msg
 
     def test_freqs(self):
         """Check frequencies shape."""
@@ -138,7 +139,7 @@ class TestPulsarPint(TestPulsar):
                          datadir + '/B1855+09_NANOGrav_9yv1.tim',
                          ephem='DE430', timing_package='pint')
 
-    # exclude tests pending implementation of .stoas, .dm, .dmx in PintPulsar 
+    # exclude tests pending implementation of .stoas, .dm, .dmx in PintPulsar
 
     def test_stoas(self):
         pass


### PR DESCRIPTION
This is needed to experiment with wideband likelihoods.

It adds Tempo2Pulsar properties stoas (returns array of observatory TOAs in seconds), dm (returns DM parameter from parfile), dmx (returns a dictionary of DMX-parameter values and corresponding stoa ranges).

Tests pass, but are excluded for PintPulsar. Somebody with PINT experience could add these attributes also for PINT.