### PR TITLE
User-defined Frequency Array for `createfourierdesignmatrix_red()`

### DIFF
--- a/enterprise/signals/gp_signals.py
+++ b/enterprise/signals/gp_signals.py
@@ -94,11 +94,12 @@ def BasisGP(priorFunction, basisFunction,
 
 def FourierBasisGP(spectrum, components=20,
                    selection=Selection(selections.no_selection),
-                   Tspan=None, name=''):
+                   Tspan=None, modes=None, name=''):
     """Convenience function to return a BasisGP class with a
     fourier basis."""
 
-    basis = utils.createfourierdesignmatrix_red(nmodes=components, Tspan=Tspan)
+    basis = utils.createfourierdesignmatrix_red(nmodes=components, 
+                                                Tspan=Tspan, modes=modes)
     BaseClass = BasisGP(spectrum, basis, selection=selection, name=name)
 
     class FourierBasisGP(BaseClass):

--- a/enterprise/signals/gp_signals.py
+++ b/enterprise/signals/gp_signals.py
@@ -98,7 +98,7 @@ def FourierBasisGP(spectrum, components=20,
     """Convenience function to return a BasisGP class with a
     fourier basis."""
 
-    basis = utils.createfourierdesignmatrix_red(nmodes=components, 
+    basis = utils.createfourierdesignmatrix_red(nmodes=components,
                                                 Tspan=Tspan, modes=modes)
     BaseClass = BasisGP(spectrum, basis, selection=selection, name=name)
 

--- a/enterprise/signals/utils.py
+++ b/enterprise/signals/utils.py
@@ -49,7 +49,7 @@ def create_stabletimingdesignmatrix(designmat, fastDesign=True):
 @signal_base.function
 def createfourierdesignmatrix_red(toas, nmodes=30, Tspan=None,
                                   logf=False, fmin=None, fmax=None,
-                                  pshift=False):
+                                  pshift=False, modes=None):
     """
     Construct fourier design matrix from eq 11 of Lentati et al, 2013
     :param toas: vector of time series in seconds
@@ -60,17 +60,18 @@ def createfourierdesignmatrix_red(toas, nmodes=30, Tspan=None,
     :param fmin: lower sampling frequency
     :param fmax: upper sampling frequency
     :param pshift: option to add random phase shift
+    :param modes: option to provide explicit list or array of sampling frequencies
     :return: F: fourier design matrix
     :return: f: Sampling frequencies
     """
 
-    N = len(toas)
-    F = np.zeros((N, 2 * nmodes))
-
     T = Tspan if Tspan is not None else toas.max() - toas.min()
 
     # define sampling frequencies
-    if fmin is None and fmax is None and not logf:
+    if modes is not None:
+        nmodes = len(modes)
+        f = modes
+    elif fmin is None and fmax is None and not logf:
         # make sure partially overlapping sets of modes
         # have identical frequencies
         f = 1.0 * np.arange(1, nmodes + 1) / T
@@ -94,6 +95,9 @@ def createfourierdesignmatrix_red(toas, nmodes=30, Tspan=None,
 
     Ffreqs = np.repeat(f, 2)
 
+    N = len(toas)
+    F = np.zeros((N, 2 * nmodes))
+
     # The sine/cosine modes
     F[:,::2] = np.sin(2*np.pi*toas[:,None]*f[None,:] +
                       ranphase[None,:])
@@ -105,7 +109,8 @@ def createfourierdesignmatrix_red(toas, nmodes=30, Tspan=None,
 
 @signal_base.function
 def createfourierdesignmatrix_dm(toas, freqs, nmodes=30, Tspan=None,
-                                 logf=False, fmin=None, fmax=None):
+                                 pshift=False, logf=False, fmin=None,
+                                 fmax=None, modes=None):
 
     """
     Construct DM-variation fourier design matrix.
@@ -126,7 +131,7 @@ def createfourierdesignmatrix_dm(toas, freqs, nmodes=30, Tspan=None,
     # get base fourier design matrix and frequencies
     F, Ffreqs = createfourierdesignmatrix_red(
         toas, nmodes=nmodes, Tspan=Tspan, logf=logf,
-        fmin=fmin, fmax=fmax)
+        fmin=fmin, fmax=fmax, pshift=pshift, modes=modes)
 
     # compute the DM-variation vectors
     # TODO: should we use a different normalization

--- a/enterprise/signals/utils.py
+++ b/enterprise/signals/utils.py
@@ -145,7 +145,8 @@ def createfourierdesignmatrix_dm(toas, freqs, nmodes=30, Tspan=None,
 @signal_base.function
 def createfourierdesignmatrix_env(toas, log10_Amp=-7, log10_Q=np.log10(300),
                                   t0=53000*86400, nmodes=30, Tspan=None,
-                                  logf=False, fmin=None, fmax=None, modes=None):
+                                  logf=False, fmin=None, fmax=None,
+                                  modes=None):
     """
     Construct fourier design matrix with gaussian envelope.
 

--- a/enterprise/signals/utils.py
+++ b/enterprise/signals/utils.py
@@ -60,7 +60,8 @@ def createfourierdesignmatrix_red(toas, nmodes=30, Tspan=None,
     :param fmin: lower sampling frequency
     :param fmax: upper sampling frequency
     :param pshift: option to add random phase shift
-    :param modes: option to provide explicit list or array of sampling frequencies
+    :param modes: option to provide explicit list or array of
+                  sampling frequencies
     :return: F: fourier design matrix
     :return: f: Sampling frequencies
     """

--- a/enterprise/signals/utils.py
+++ b/enterprise/signals/utils.py
@@ -62,6 +62,7 @@ def createfourierdesignmatrix_red(toas, nmodes=30, Tspan=None,
     :param pshift: option to add random phase shift
     :param modes: option to provide explicit list or array of
                   sampling frequencies
+
     :return: F: fourier design matrix
     :return: f: Sampling frequencies
     """
@@ -124,6 +125,9 @@ def createfourierdesignmatrix_dm(toas, freqs, nmodes=30, Tspan=None,
     :param logf: use log frequency spacing
     :param fmin: lower sampling frequency
     :param fmax: upper sampling frequency
+    :param pshift: option to add random phase shift
+    :param modes: option to provide explicit list or array of
+                  sampling frequencies
 
     :return: F: DM-variation fourier design matrix
     :return: f: Sampling frequencies
@@ -161,6 +165,8 @@ def createfourierdesignmatrix_env(toas, log10_Amp=-7, log10_Q=np.log10(300),
     :param log10_Amp: log10 of the Amplitude [s]
     :param t0: mean of gaussian envelope [s]
     :param log10_Q: log10 of standard deviation of gaussian envelope [days]
+    :param modes: option to provide explicit list or array of
+                  sampling frequencies
 
     :return: F: fourier design matrix with gaussian envelope
     :return: f: Sampling frequencies
@@ -194,6 +200,8 @@ def createfourierdesignmatrix_eph(t, nmodes, phi, theta, freq=False,
     :param logf: use log frequency spacing
     :param fmin: lower sampling frequency
     :param fmax: upper sampling frequency
+    :param modes: option to provide explicit list or array of
+                  sampling frequencies
 
     :return: Fx: x-axis ephemeris fourier design matrix
     :return: Fy: y-axis ephemeris fourier design matrix

--- a/enterprise/signals/utils.py
+++ b/enterprise/signals/utils.py
@@ -145,7 +145,7 @@ def createfourierdesignmatrix_dm(toas, freqs, nmodes=30, Tspan=None,
 @signal_base.function
 def createfourierdesignmatrix_env(toas, log10_Amp=-7, log10_Q=np.log10(300),
                                   t0=53000*86400, nmodes=30, Tspan=None,
-                                  logf=False, fmin=None, fmax=None):
+                                  logf=False, fmin=None, fmax=None, modes=None):
     """
     Construct fourier design matrix with gaussian envelope.
 
@@ -168,7 +168,7 @@ def createfourierdesignmatrix_env(toas, log10_Amp=-7, log10_Q=np.log10(300),
     # get base fourier design matrix and frequencies
     F, Ffreqs = createfourierdesignmatrix_red(
         toas, nmodes=nmodes, Tspan=Tspan, logf=logf,
-        fmin=fmin, fmax=fmax)
+        fmin=fmin, fmax=fmax, modes=modes)
 
     # compute gaussian envelope
     A = 10**log10_Amp
@@ -179,7 +179,7 @@ def createfourierdesignmatrix_env(toas, log10_Amp=-7, log10_Q=np.log10(300),
 
 def createfourierdesignmatrix_eph(t, nmodes, phi, theta, freq=False,
                                   Tspan=None, logf=False, fmin=None,
-                                  fmax=None):
+                                  fmax=None, modes=None):
 
     """
     Construct ephemeris fourier design matrix.
@@ -200,18 +200,16 @@ def createfourierdesignmatrix_eph(t, nmodes, phi, theta, freq=False,
     :return: f: Sampling frequencies (if freq=True)
     """
 
-    N = len(t)
-    Fx = np.zeros((N, 2*nmodes))
-    Fy = np.zeros((N, 2*nmodes))
-    Fz = np.zeros((N, 2*nmodes))
-
     if Tspan is not None:
         T = Tspan
     else:
         T = t.max() - t.min()
 
     # define sampling frequencies
-    if fmin is not None and fmax is not None:
+    if modes is not None:
+        nmodes = len(modes)
+        f = modes
+    elif fmin is not None and fmax is not None:
         f = np.linspace(fmin, fmax, nmodes)
     else:
         f = np.linspace(1 / T, nmodes / T, nmodes)
@@ -226,6 +224,11 @@ def createfourierdesignmatrix_eph(t, nmodes, phi, theta, freq=False,
     x = np.sin(theta)*np.cos(phi)
     y = np.sin(theta)*np.sin(phi)
     z = np.cos(theta)
+
+    N = len(t)
+    Fx = np.zeros((N, 2*nmodes))
+    Fy = np.zeros((N, 2*nmodes))
+    Fz = np.zeros((N, 2*nmodes))
 
     # The sine/cosine modes
     Fx[:,::2] = np.sin(2*np.pi*t[:,None]*f[None,:])

--- a/tests/test_gp_signals.py
+++ b/tests/test_gp_signals.py
@@ -248,24 +248,21 @@ class TestGPSignals(unittest.TestCase):
     def test_fourier_red_user_freq_array(self):
         """Test that red noise signal returns correct values with user defined
         frequency array."""
-        #Calculate time span for user defined frequencies.
-        Tspan = self.psr.toas.max() - self.psr.toas.min()
-        freqs = np.linspace(1/Tspan, 30/Tspan, 30)
-
-        # set up signal parameter
-        pl = utils.powerlaw(log10_A=parameter.Uniform(-18,-12),
-                            gamma=parameter.Uniform(1,7))
-        rn = gs.FourierBasisGP(spectrum=pl, modes=freqs)
-        rnm = rn(self.psr)
-
-        # parameters
+        # set parameters
         log10_A, gamma = -14.5, 4.33
         params = {'B1855+09_log10_A': log10_A,
                   'B1855+09_gamma': gamma}
 
-        # basis matrix test
         F, f2 = utils.createfourierdesignmatrix_red(
             self.psr.toas, nmodes=30)
+
+        # set up signal model. use list of frequencies to make basis
+        pl = utils.powerlaw(log10_A=parameter.Uniform(-18,-12),
+                            gamma=parameter.Uniform(1,7))
+        rn = gs.FourierBasisGP(spectrum=pl, modes=f2[::2])
+        rnm = rn(self.psr)
+
+        # basis matrix test
         msg = 'F matrix incorrect for GP Fourier signal.'
         assert np.allclose(F, rnm.get_basis(params)), msg
 

--- a/tests/test_gp_signals.py
+++ b/tests/test_gp_signals.py
@@ -245,6 +245,43 @@ class TestGPSignals(unittest.TestCase):
         msg = 'F matrix shape incorrect'
         assert rnm.get_basis(params).shape == F.shape, msg
 
+    def test_fourier_red_user_freq_array(self):
+        """Test that red noise signal returns correct values with user defined
+        frequency array."""
+        #Calculate time span for user defined frequencies.
+        Tspan = self.psr.toas.max() - self.psr.toas.min()
+        freqs = np.linspace(1/Tspan, 30/Tspan, 30)
+
+        # set up signal parameter
+        pl = utils.powerlaw(log10_A=parameter.Uniform(-18,-12),
+                            gamma=parameter.Uniform(1,7))
+        rn = gs.FourierBasisGP(spectrum=pl, modes=freqs)
+        rnm = rn(self.psr)
+
+        # parameters
+        log10_A, gamma = -14.5, 4.33
+        params = {'B1855+09_log10_A': log10_A,
+                  'B1855+09_gamma': gamma}
+
+        # basis matrix test
+        F, f2 = utils.createfourierdesignmatrix_red(
+            self.psr.toas, nmodes=30)
+        msg = 'F matrix incorrect for GP Fourier signal.'
+        assert np.allclose(F, rnm.get_basis(params)), msg
+
+        # spectrum test
+        phi = utils.powerlaw(f2, log10_A=log10_A, gamma=gamma)
+        msg = 'Spectrum incorrect for GP Fourier signal.'
+        assert np.all(rnm.get_phi(params) == phi), msg
+
+        # inverse spectrum test
+        msg = 'Spectrum inverse incorrect for GP Fourier signal.'
+        assert np.all(rnm.get_phiinv(params) == 1/phi), msg
+
+        # test shape
+        msg = 'F matrix shape incorrect'
+        assert rnm.get_basis(params).shape == F.shape, msg
+
     def test_fourier_red_noise_backend(self):
         """Test that red noise-backend signal returns correct values."""
         # set up signal parameter


### PR DESCRIPTION
This pull request adds the ability for a user to make an array of arbitrary frequencies for input into the `createfourierdesignmatrix_red()` method. This array need not be evenly sampled, and is added with the keyword argument `modes`. Frequencies should be entered in Hz. The frequencies can either be added as a list or a `numpy.ndarray`.

Sample usage. Here we add in a 1/year frequency to sample over. 

```python
Tspan = psr.toas.max() - psr.toas.min()
freqs = np.linspace(1/Tspan, 30/Tspan, 30)
yr_freq = 1/(365.25*24*3600) 
freqs = np.sort(np.concatenate((freqs,yr_freq)))

pl = enterprise.utils.powerlaw(log10_A=parameter.Uniform(-18,-12), 
        gamma=parameter.Uniform(1,7))
rn = enterprise.gp_signals.FourierBasisGP(spectrum=pl, modes=freqs)
rnm = rn(psr)
```

While the example above uses a power law psd, this feature will be most useful when modeling something with a free spectral model or t-process, where one expects physically motivated features at specific frequencies. 

I've also added the kwarg `pshift` to `createfourierdesignmatrix_dm()` in order to be able to use this feature of the underlying `createfourierdesignmatrix_red()`.