### PR TITLE
use numpy 1.16.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.16.0
+numpy==1.16.3
 scipy==1.2.0
 ephem>=3.7.6.0
 Cython==0.28.5


### PR DESCRIPTION
I think this fixes the `numpy.load()` problem in py2.7.

Another option is to wrap all or our input to `numpy.load()` in `str()`.  These calls only appear in `enterprise/signals/utils.py` and `tests/test_deterministic_signals.py`.

The former keeps the code the same as before, the latter supports more numpy versions.