### PR TITLE
Allow common instantiated coefficients Parameter in BasisCommonGP

### DIFF
--- a/enterprise/signals/gp_signals.py
+++ b/enterprise/signals/gp_signals.py
@@ -310,6 +310,14 @@ def BasisCommonGP(priorFunction, basisFunction, orfFunction,
             if coefficients and pyv3:
                 self._construct_basis()
 
+                # if we're given an instantiated coefficient vector
+                # that's what we will use
+                if isinstance(coefficients, parameter.Parameter):
+                    self._coefficients[''] = coefficients
+                    self._params[coefficients.name] = coefficients
+
+                    return
+
                 chain = itertools.chain(self._prior._params.values(),
                                         self._orf._params.values(),
                                         self._bases._params.values())


### PR DESCRIPTION
As needed, e.g., to sample the coefficients of a basis-described ephemeris perturbation, writing something like:

```Python
cf = parameter.Normal(mu=np.zeros(4), sigma=phi, size=4)('eph_coefficients')
cm = gp_signals.BasisCommonGP(priorphi(), fmatfunc(), utils.monopole_orf(),
                              coefficients=cf, name='eph')
```

Note that in the case the prior and ORF will not be used; by contrast `fmatfunc()` must return the appropriate basis matrix for each pulsar.