### PR TITLE
Determine parameters recursively in PTA.param

### DIFF
--- a/enterprise/signals/parameter.py
+++ b/enterprise/signals/parameter.py
@@ -96,7 +96,10 @@ class Parameter(object):
                 raise ValueError(
                     "You shouldn't give me my value when you're sampling me.!")
 
-            return self.prior(func=self._sampler, size=self._size, **kwargs)
+            if hasattr(self,'prior'):
+                return self.prior(func=self._sampler, size=self._size, **kwargs)
+            else:
+                return self.logprior(func=self._sampler, size=self._size, **kwargs)
 
     @property
     def size(self):

--- a/enterprise/signals/parameter.py
+++ b/enterprise/signals/parameter.py
@@ -97,9 +97,11 @@ class Parameter(object):
                     "You shouldn't give me my value when you're sampling me.!")
 
             if hasattr(self,'prior'):
-                return self.prior(func=self._sampler, size=self._size, **kwargs)
+                return self.prior(func=self._sampler, size=self._size,
+                                  **kwargs)
             else:
-                return self.logprior(func=self._sampler, size=self._size, **kwargs)
+                return self.logprior(func=self._sampler, size=self._size,
+                                     **kwargs)
 
     @property
     def size(self):

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -241,9 +241,18 @@ class PTA(object):
 
     @property
     def params(self):
-        return sorted({par for signalcollection in self._signalcollections for
-                       par in signalcollection.params},
-                      key=lambda par: par.name)
+        ret = set()
+
+        for signalcollection in self._signalcollections:
+            for param in signalcollection.params:
+                for par in param.params:
+                    ret.add(par)
+
+        return sorted(list(ret), key=lambda par: par.name)
+
+        # return sorted({par for signalcollection in self._signalcollections for
+        #                par in signalcollection.params},
+        #               key=lambda par: par.name)
 
     @property
     def param_names(self):

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -250,8 +250,8 @@ class PTA(object):
 
         return sorted(list(ret), key=lambda par: par.name)
 
-        # return sorted({par for signalcollection in self._signalcollections for
-        #                par in signalcollection.params},
+        # return sorted({par for signalcollection in self._signalcollections
+        #                    for par in signalcollection.params},
         #               key=lambda par: par.name)
 
     @property


### PR DESCRIPTION
This is needed, for instance, when a UserParameter depends on a hyperparameter.

```python
def scaledlogprior(x, scale=1):
    return -0.5*np.dot(x, np.dot(phi, x))*scale**2 - 0.5*np.log(np.linalg.det(phi)) # forget the 2pi

cphi = scipy.linalg.cholesky(phi).T
def scaledsampler(scale=1, size=4):
    return scale * np.dot(cphi,np.random.randn(size))

slp = parameter.Function(scaledlogprior, scale=parameter.Uniform(0.5,1.5))

cf = parameter.UserParameter(logprior=slp, sampler=scaledsampler, size=4)('eph_coefficients')
```