### PR TITLE
Reorganizing gp bases and priors.

### DIFF
--- a/enterprise/signals/gp_bases.py
+++ b/enterprise/signals/gp_bases.py
@@ -1,0 +1,230 @@
+# gp_bases.py
+"""Utilities module containing various useful
+functions for use in other modules.
+"""
+
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+
+import numpy as np
+from enterprise.signals.parameter import function
+######################################
+# Fourier-basis signal functions #####
+######################################
+
+
+@function
+def createfourierdesignmatrix_red(toas, nmodes=30, Tspan=None,
+                                  logf=False, fmin=None, fmax=None,
+                                  pshift=False, modes=None):
+    """
+    Construct fourier design matrix from eq 11 of Lentati et al, 2013
+    :param toas: vector of time series in seconds
+    :param nmodes: number of fourier coefficients to use
+    :param freq: option to output frequencies
+    :param Tspan: option to some other Tspan
+    :param logf: use log frequency spacing
+    :param fmin: lower sampling frequency
+    :param fmax: upper sampling frequency
+    :param pshift: option to add random phase shift
+    :param modes: option to provide explicit list or array of
+                  sampling frequencies
+
+    :return: F: fourier design matrix
+    :return: f: Sampling frequencies
+    """
+
+    T = Tspan if Tspan is not None else toas.max() - toas.min()
+
+    # define sampling frequencies
+    if modes is not None:
+        nmodes = len(modes)
+        f = modes
+    elif fmin is None and fmax is None and not logf:
+        # make sure partially overlapping sets of modes
+        # have identical frequencies
+        f = 1.0 * np.arange(1, nmodes + 1) / T
+    else:
+        # more general case
+
+        if fmin is None:
+            fmin = 1 / T
+
+        if fmax is None:
+            fmax = nmodes / T
+
+        if logf:
+            f = np.logspace(np.log10(fmin), np.log10(fmax), nmodes)
+        else:
+            f = np.linspace(fmin, fmax, nmodes)
+
+    # add random phase shift to basis functions
+    ranphase = (np.random.uniform(0.0, 2 * np.pi, nmodes)
+                if pshift else np.zeros(nmodes))
+
+    Ffreqs = np.repeat(f, 2)
+
+    N = len(toas)
+    F = np.zeros((N, 2 * nmodes))
+
+    # The sine/cosine modes
+    F[:, ::2] = np.sin(2*np.pi*toas[:, None]*f[None, :] +
+                       ranphase[None, :])
+    F[:, 1::2] = np.cos(2*np.pi*toas[:, None]*f[None, :] +
+                        ranphase[None, :])
+
+    return F, Ffreqs
+
+
+@function
+def createfourierdesignmatrix_dm(toas, freqs, nmodes=30, Tspan=None,
+                                 pshift=False, fref=1400, logf=False,
+                                 fmin=None, fmax=None, modes=None):
+    """
+    Construct DM-variation fourier design matrix. Current
+    normalization expresses DM signal as a deviation [seconds]
+    at fref [MHz]
+
+    :param toas: vector of time series in seconds
+    :param freqs: radio frequencies of observations [MHz]
+    :param nmodes: number of fourier coefficients to use
+    :param Tspan: option to some other Tspan
+    :param pshift: option to add random phase shift
+    :param fref: reference frequency [MHz]
+    :param logf: use log frequency spacing
+    :param fmin: lower sampling frequency
+    :param fmax: upper sampling frequency
+    :param modes: option to provide explicit list or array of
+                  sampling frequencies
+
+    :return: F: DM-variation fourier design matrix
+    :return: f: Sampling frequencies
+    """
+
+    # get base fourier design matrix and frequencies
+    F, Ffreqs = createfourierdesignmatrix_red(
+        toas, nmodes=nmodes, Tspan=Tspan, logf=logf,
+        fmin=fmin, fmax=fmax, pshift=pshift, modes=modes)
+
+    # compute the DM-variation vectors
+    Dm = (fref/freqs)**2
+
+    return F * Dm[:, None], Ffreqs
+
+
+@function
+def createfourierdesignmatrix_env(toas, log10_Amp=-7, log10_Q=np.log10(300),
+                                  t0=53000*86400, nmodes=30, Tspan=None,
+                                  logf=False, fmin=None, fmax=None,
+                                  modes=None):
+    """
+    Construct fourier design matrix with gaussian envelope.
+
+    :param toas: vector of time series in seconds
+    :param nmodes: number of fourier coefficients to use
+    :param freqs: radio frequencies of observations [MHz]
+    :param freq: option to output frequencies
+    :param Tspan: option to some other Tspan
+    :param logf: use log frequency spacing
+    :param fmin: lower sampling frequency
+    :param fmax: upper sampling frequency
+    :param log10_Amp: log10 of the Amplitude [s]
+    :param t0: mean of gaussian envelope [s]
+    :param log10_Q: log10 of standard deviation of gaussian envelope [days]
+    :param modes: option to provide explicit list or array of
+                  sampling frequencies
+
+    :return: F: fourier design matrix with gaussian envelope
+    :return: f: Sampling frequencies
+    """
+
+    # get base fourier design matrix and frequencies
+    F, Ffreqs = createfourierdesignmatrix_red(
+        toas, nmodes=nmodes, Tspan=Tspan, logf=logf,
+        fmin=fmin, fmax=fmax, modes=modes)
+
+    # compute gaussian envelope
+    A = 10**log10_Amp
+    Q = 10**log10_Q * 86400
+    env = A * np.exp(-(toas-t0)**2/2/Q**2)
+    return F * env[:, None], Ffreqs
+
+
+@function
+def createfourierdesignmatrix_ephem(toas, pos, nmodes=30, Tspan=None):
+    """
+    Construct ephemeris perturbation Fourier design matrix and frequencies.
+    The matrix contains nmodes*6 columns, ordered as by frequency first,
+    Cartesian coordinate second:
+
+    sin(f0) [x], sin(f0) [y], sin(f0) [z],
+    cos(f0) [x], cos(f0) [y], cos(f0) [z],
+    sin(f1) [x], sin(f1) [y], sin(f1) [z], ...
+
+    The corresponding frequency vector repeats every entry six times.
+    This design matrix should be used with monopole_orf and with
+    a powerlaw that specifies components=6.
+
+    :param toas: vector of time series in seconds
+    :param pos: pulsar position as Cartesian vector
+    :param nmodes: number of Fourier coefficients
+    :param Tspan: Tspan used to define Fourier bins
+
+    :return: F: Fourier design matrix of shape (len(toas),6*nmodes)
+    :return: f: Sampling frequencies (6*nmodes)
+    """
+
+    F0, F0f = createfourierdesignmatrix_red(
+        toas, nmodes=nmodes, Tspan=Tspan)
+
+    F1 = np.zeros((len(toas), nmodes, 2, 3), 'd')
+    F1[:, :, 0, :] = F0[:, 0::2, np.newaxis]
+    F1[:, :, 1, :] = F0[:, 1::2, np.newaxis]
+
+    # verify this is the scalar product we want
+    F1 *= pos
+
+    F1f = np.zeros((nmodes, 2, 3), 'd')
+    F1f[:, :, :] = F0f[::2, np.newaxis, np.newaxis]
+
+    return F1.reshape((len(toas), nmodes*6)), F1f.reshape((nmodes*6, ))
+
+
+def createfourierdesignmatrix_eph(t, nmodes, phi, theta, freq=False,
+                                  Tspan=None, logf=False, fmin=None,
+                                  fmax=None, modes=None):
+    raise NotImplementedError(
+        "createfourierdesignmatrix_eph was removed, " +
+        "and replaced with createfourierdesignmatrix_ephem")
+
+
+@function
+def createfourierdesignmatrix_chromatic(toas, freqs, nmodes=30, Tspan=None,
+                                        logf=False, fmin=None, fmax=None,
+                                        idx=4):
+
+    """
+    Construct Scattering-variation fourier design matrix.
+
+    :param toas: vector of time series in seconds
+    :param freqs: radio frequencies of observations [MHz]
+    :param nmodes: number of fourier coefficients to use
+    :param freq: option to output frequencies
+    :param Tspan: option to some other Tspan
+    :param logf: use log frequency spacing
+    :param fmin: lower sampling frequency
+    :param fmax: upper sampling frequency
+    :param idx: Index of chromatic effects
+
+    :return: F: Chromatic-variation fourier design matrix
+    :return: f: Sampling frequencies
+    """
+
+    # get base fourier design matrix and frequencies
+    F, Ffreqs = createfourierdesignmatrix_red(toas, nmodes=nmodes, Tspan=Tspan,
+                                              logf=logf, fmin=fmin, fmax=fmax)
+
+    # compute the DM-variation vectors
+    Dm = (1400/freqs) ** idx
+
+    return F * Dm[:, None], Ffreqs

--- a/enterprise/signals/gp_bases.py
+++ b/enterprise/signals/gp_bases.py
@@ -18,6 +18,7 @@ __all__ = ['createfourierdesignmatrix_red',
            'createfourierdesignmatrix_ephem',
            'createfourierdesignmatrix_eph']
 
+
 @function
 def createfourierdesignmatrix_red(toas, nmodes=30, Tspan=None,
                                   logf=False, fmin=None, fmax=None,

--- a/enterprise/signals/gp_bases.py
+++ b/enterprise/signals/gp_bases.py
@@ -12,6 +12,11 @@ from enterprise.signals.parameter import function
 # Fourier-basis signal functions #####
 ######################################
 
+__all__ = ['createfourierdesignmatrix_red',
+           'createfourierdesignmatrix_dm',
+           'createfourierdesignmatrix_env',
+           'createfourierdesignmatrix_ephem',
+           'createfourierdesignmatrix_eph']
 
 @function
 def createfourierdesignmatrix_red(toas, nmodes=30, Tspan=None,

--- a/enterprise/signals/gp_priors.py
+++ b/enterprise/signals/gp_priors.py
@@ -1,0 +1,145 @@
+# gp_priors.py
+"""Utilities module containing various useful
+functions for use in other modules.
+"""
+
+from __future__ import (absolute_import, division,
+                        print_function, unicode_literals)
+
+import numpy as np
+import scipy.stats
+
+from enterprise.signals import parameter
+from enterprise.signals.parameter import function
+import enterprise.constants as const
+
+
+@function
+def powerlaw(f, log10_A=-16, gamma=5, components=2):
+    df = np.diff(np.concatenate((np.array([0]), f[::components])))
+    return ((10**log10_A)**2 / 12.0 / np.pi**2 *
+            const.fyr**(gamma-3) * f**(-gamma) * np.repeat(df, components))
+
+
+@function
+def turnover(f, log10_A=-15, gamma=4.33, lf0=-8.5, kappa=10/3, beta=0.5):
+    df = np.diff(np.concatenate((np.array([0]), f[::2])))
+    hcf = (10**log10_A * (f / const.fyr) ** ((3-gamma) / 2) /
+           (1 + (10**lf0 / f) ** kappa) ** beta)
+    return hcf**2/12/np.pi**2/f**3*np.repeat(df, 2)
+
+
+@function
+def free_spectrum(f, log10_rho=None):
+    """
+    Free spectral model. PSD  amplitude at each frequency
+    is a free parameter. Model is parameterized by
+    S(f_i) = \rho_i^2 * T,
+    where \rho_i is the free parameter and T is the observation
+    length.
+    """
+    return np.repeat(10**(2*np.array(log10_rho)), 2)
+
+
+@function
+def t_process(f, log10_A=-15, gamma=4.33, alphas=None):
+    """
+    t-process model. PSD  amplitude at each frequency
+    is a fuzzy power-law.
+    """
+    alphas = np.ones_like(f) if alphas is None else np.repeat(alphas, 2)
+    return powerlaw(f, log10_A=log10_A, gamma=gamma) * alphas
+
+
+@function
+def t_process_adapt(f, log10_A=-15, gamma=4.33, alphas_adapt=None, nfreq=None):
+    """
+    t-process model. PSD  amplitude at each frequency
+    is a fuzzy power-law.
+    """
+    if alphas_adapt is None:
+        alpha_model = np.ones_like(f)
+    else:
+        if nfreq is None:
+            alpha_model = np.repeat(alphas_adapt, 2)
+        else:
+            alpha_model = np.ones_like(f)
+            alpha_model[2*int(np.rint(nfreq))] = alphas_adapt
+            alpha_model[2*int(np.rint(nfreq))+1] = alphas_adapt
+
+    return powerlaw(f, log10_A=log10_A, gamma=gamma) * alpha_model
+
+
+def InvGammaPrior(value, alpha=1, gamma=1):
+    """Prior function for InvGamma parameters."""
+    return scipy.stats.invgamma.pdf(value, alpha, scale=gamma)
+
+
+def InvGammaSampler(alpha=1, gamma=1, size=None):
+    """Sampling function for Uniform parameters."""
+    return scipy.stats.invgamma.rvs(alpha, scale=gamma, size=size)
+
+
+def InvGamma(alpha=1, gamma=1, size=None):
+    """Class factory for Inverse Gamma parameters."""
+    class InvGamma(parameter.Parameter):
+        _size = size
+        _prior = parameter.Function(InvGammaPrior, alpha=alpha, gamma=gamma)
+        _sampler = staticmethod(InvGammaSampler)
+        _alpha = alpha
+        _gamma = gamma
+
+        def __repr__(self):
+            return '"{}": InvGamma({},{})'.format(self.name, alpha, gamma) \
+                + ('' if self._size is None else '[{}]'.format(self._size))
+
+    return InvGamma
+
+
+@function
+def turnover_knee(f, log10_A, gamma, lfb, lfk, kappa, delta):
+    """
+    Generic turnover spectrum with a high-frequency knee.
+    :param f: sampling frequencies of GWB
+    :param A: characteristic strain amplitude at f=1/yr
+    :param gamma: negative slope of PSD around f=1/yr (usually 13/3)
+    :param lfb: log10 transition frequency at which environment dominates GWs
+    :param lfk: log10 knee frequency due to population finiteness
+    :param kappa: smoothness of turnover (10/3 for 3-body stellar scattering)
+    :param delta: slope at higher frequencies
+    """
+    df = np.diff(np.concatenate((np.array([0]), f[::2])))
+    hcf = (10**log10_A * (f / const.fyr) ** ((3-gamma) / 2) *
+           (1.0 + (f / 10**lfk)) ** delta /
+           np.sqrt(1 + (10**lfb / f) ** kappa))
+    return hcf**2 / 12 / np.pi**2 / f**3 * np.repeat(df, 2)
+
+
+@function
+def broken_powerlaw(f, log10_A, gamma, delta, log10_fb, kappa=0.1):
+    """
+    Generic broken powerlaw spectrum.
+    :param f: sampling frequencies
+    :param A: characteristic strain amplitude [set for gamma at f=1/yr]
+    :param gamma: negative slope of PSD for f > f_break [set for comparison
+        at f=1/yr (default 13/3)]
+    :param delta: slope for frequencies < f_break
+    :param log10_fb: log10 transition frequency at which slope switches from
+        gamma to delta
+    :param kappa: smoothness of transition (Default = 0.1)
+    """
+    df = np.diff(np.concatenate((np.array([0]), f[::2])))
+    hcf = (10**log10_A * (f / const.fyr) ** ((3-gamma) / 2) *
+           (1 + (f / 10**log10_fb) ** (1/kappa)) **
+           (kappa * (gamma - delta) / 2))
+    return hcf**2 / 12 / np.pi**2 / f**3 * np.repeat(df, 2)
+
+
+@function
+def powerlaw_genmodes(f, log10_A=-16, gamma=5, components=2, wgts=None):
+    if wgts is not None:
+        df = wgts**2
+    else:
+        df = np.diff(np.concatenate((np.array([0]), f[::components])))
+    return ((10**log10_A)**2 / 12.0 / np.pi**2 *
+            const.fyr**(gamma-3) * f**(-gamma) * np.repeat(df, components))

--- a/enterprise/signals/utils.py
+++ b/enterprise/signals/utils.py
@@ -21,7 +21,13 @@ import enterprise
 import enterprise.constants as const
 from enterprise.signals.parameter import function
 from enterprise.signals.gp_priors import powerlaw, turnover  # noqa: F401
-from enterprise.signals.gp_bases import *  # noqa: F401, F403
+import enterprise.signals as sigs  # noqa: F401
+from enterprise.signals.gp_bases import (  # noqa: F401
+                                         createfourierdesignmatrix_red,
+                                         createfourierdesignmatrix_dm,
+                                         createfourierdesignmatrix_env,
+                                         createfourierdesignmatrix_ephem,
+                                         createfourierdesignmatrix_eph)
 
 
 try:

--- a/enterprise/signals/utils.py
+++ b/enterprise/signals/utils.py
@@ -1,5 +1,6 @@
-#utils.py
-"""Utilities module containing various useful
+# utils.py
+"""
+Utilities module containing various useful
 functions for use in other modules.
 """
 
@@ -19,6 +20,12 @@ from pkg_resources import resource_filename, Requirement
 import enterprise
 import enterprise.constants as const
 from enterprise.signals.parameter import function
+from enterprise.signals.gp_priors import powerlaw, turnover
+from enterprise.signals.gp_bases import (createfourierdesignmatrix_red,
+                                         createfourierdesignmatrix_dm,
+                                         createfourierdesignmatrix_env,
+                                         createfourierdesignmatrix_ephem,
+                                         createfourierdesignmatrix_eph)
 
 try:
     from sksparse.cholmod import cholesky
@@ -224,196 +231,6 @@ def create_stabletimingdesignmatrix(designmat, fastDesign=True):
         Mm = u[:, :len(s)]
 
     return Mm
-
-
-######################################
-# Fourier-basis signal functions #####
-######################################
-
-
-@function
-def createfourierdesignmatrix_red(toas, nmodes=30, Tspan=None,
-                                  logf=False, fmin=None, fmax=None,
-                                  pshift=False, modes=None):
-    """
-    Construct fourier design matrix from eq 11 of Lentati et al, 2013
-    :param toas: vector of time series in seconds
-    :param nmodes: number of fourier coefficients to use
-    :param freq: option to output frequencies
-    :param Tspan: option to some other Tspan
-    :param logf: use log frequency spacing
-    :param fmin: lower sampling frequency
-    :param fmax: upper sampling frequency
-    :param pshift: option to add random phase shift
-    :param modes: option to provide explicit list or array of
-                  sampling frequencies
-
-    :return: F: fourier design matrix
-    :return: f: Sampling frequencies
-    """
-
-    T = Tspan if Tspan is not None else toas.max() - toas.min()
-
-    # define sampling frequencies
-    if modes is not None:
-        nmodes = len(modes)
-        f = modes
-    elif fmin is None and fmax is None and not logf:
-        # make sure partially overlapping sets of modes
-        # have identical frequencies
-        f = 1.0 * np.arange(1, nmodes + 1) / T
-    else:
-        # more general case
-
-        if fmin is None:
-            fmin = 1 / T
-
-        if fmax is None:
-            fmax = nmodes / T
-
-        if logf:
-            f = np.logspace(np.log10(fmin), np.log10(fmax), nmodes)
-        else:
-            f = np.linspace(fmin, fmax, nmodes)
-
-    # add random phase shift to basis functions
-    ranphase = (np.random.uniform(0.0, 2 * np.pi, nmodes)
-                if pshift else np.zeros(nmodes))
-
-    Ffreqs = np.repeat(f, 2)
-
-    N = len(toas)
-    F = np.zeros((N, 2 * nmodes))
-
-    # The sine/cosine modes
-    F[:,::2] = np.sin(2*np.pi*toas[:,None]*f[None,:] +
-                      ranphase[None,:])
-    F[:,1::2] = np.cos(2*np.pi*toas[:,None]*f[None,:] +
-                       ranphase[None,:])
-
-    return F, Ffreqs
-
-
-@function
-def createfourierdesignmatrix_dm(toas, freqs, nmodes=30, Tspan=None,
-                                 pshift=False, fref=1400, logf=False,
-                                 fmin=None, fmax=None, modes=None):
-    """
-    Construct DM-variation fourier design matrix. Current
-    normalization expresses DM signal as a deviation [seconds]
-    at fref [MHz]
-
-    :param toas: vector of time series in seconds
-    :param freqs: radio frequencies of observations [MHz]
-    :param nmodes: number of fourier coefficients to use
-    :param Tspan: option to some other Tspan
-    :param pshift: option to add random phase shift
-    :param fref: reference frequency [MHz]
-    :param logf: use log frequency spacing
-    :param fmin: lower sampling frequency
-    :param fmax: upper sampling frequency
-    :param modes: option to provide explicit list or array of
-                  sampling frequencies
-
-    :return: F: DM-variation fourier design matrix
-    :return: f: Sampling frequencies
-    """
-
-    # get base fourier design matrix and frequencies
-    F, Ffreqs = createfourierdesignmatrix_red(
-        toas, nmodes=nmodes, Tspan=Tspan, logf=logf,
-        fmin=fmin, fmax=fmax, pshift=pshift, modes=modes)
-
-    # compute the DM-variation vectors
-    Dm = (fref/freqs)**2
-
-    return F * Dm[:, None], Ffreqs
-
-
-@function
-def createfourierdesignmatrix_env(toas, log10_Amp=-7, log10_Q=np.log10(300),
-                                  t0=53000*86400, nmodes=30, Tspan=None,
-                                  logf=False, fmin=None, fmax=None,
-                                  modes=None):
-    """
-    Construct fourier design matrix with gaussian envelope.
-
-    :param toas: vector of time series in seconds
-    :param nmodes: number of fourier coefficients to use
-    :param freqs: radio frequencies of observations [MHz]
-    :param freq: option to output frequencies
-    :param Tspan: option to some other Tspan
-    :param logf: use log frequency spacing
-    :param fmin: lower sampling frequency
-    :param fmax: upper sampling frequency
-    :param log10_Amp: log10 of the Amplitude [s]
-    :param t0: mean of gaussian envelope [s]
-    :param log10_Q: log10 of standard deviation of gaussian envelope [days]
-    :param modes: option to provide explicit list or array of
-                  sampling frequencies
-
-    :return: F: fourier design matrix with gaussian envelope
-    :return: f: Sampling frequencies
-    """
-
-    # get base fourier design matrix and frequencies
-    F, Ffreqs = createfourierdesignmatrix_red(
-        toas, nmodes=nmodes, Tspan=Tspan, logf=logf,
-        fmin=fmin, fmax=fmax, modes=modes)
-
-    # compute gaussian envelope
-    A = 10**log10_Amp
-    Q = 10**log10_Q * 86400
-    env = A * np.exp(-(toas-t0)**2/2/Q**2)
-    return F * env[:, None], Ffreqs
-
-
-@function
-def createfourierdesignmatrix_ephem(toas, pos, nmodes=30, Tspan=None):
-    """
-    Construct ephemeris perturbation Fourier design matrix and frequencies.
-    The matrix contains nmodes*6 columns, ordered as by frequency first,
-    Cartesian coordinate second:
-
-    sin(f0) [x], sin(f0) [y], sin(f0) [z],
-    cos(f0) [x], cos(f0) [y], cos(f0) [z],
-    sin(f1) [x], sin(f1) [y], sin(f1) [z], ...
-
-    The corresponding frequency vector repeats every entry six times.
-    This design matrix should be used with monopole_orf and with
-    a powerlaw that specifies components=6.
-
-    :param toas: vector of time series in seconds
-    :param pos: pulsar position as Cartesian vector
-    :param nmodes: number of Fourier coefficients
-    :param Tspan: Tspan used to define Fourier bins
-
-    :return: F: Fourier design matrix of shape (len(toas),6*nmodes)
-    :return: f: Sampling frequencies (6*nmodes)
-    """
-
-    F0, F0f = createfourierdesignmatrix_red(
-        toas, nmodes=nmodes, Tspan=Tspan)
-
-    F1 = np.zeros((len(toas),nmodes,2,3), 'd')
-    F1[:,:,0,:] = F0[:,0::2,np.newaxis]
-    F1[:,:,1,:] = F0[:,1::2,np.newaxis]
-
-    # verify this is the scalar product we want
-    F1 *= pos
-
-    F1f = np.zeros((nmodes,2,3), 'd')
-    F1f[:,:,:] = F0f[::2,np.newaxis,np.newaxis]
-
-    return F1.reshape((len(toas),nmodes*6)), F1f.reshape((nmodes*6,))
-
-
-def createfourierdesignmatrix_eph(t, nmodes, phi, theta, freq=False,
-                                  Tspan=None, logf=False, fmin=None,
-                                  fmax=None, modes=None):
-    raise NotImplementedError(
-        "createfourierdesignmatrix_eph was removed, " +
-        "and replaced with createfourierdesignmatrix_ephem")
 
 
 ###################################
@@ -921,21 +738,6 @@ def linear_interp_basis(toas, dt=30*86400):
     return M[:, idx], x[idx]
 
 
-@function
-def powerlaw(f, log10_A=-16, gamma=5, components=2):
-    df = np.diff(np.concatenate((np.array([0]), f[::components])))
-    return ((10**log10_A)**2 / 12.0 / np.pi**2 *
-            const.fyr**(gamma-3) * f**(-gamma) * np.repeat(df, components))
-
-
-@function
-def turnover(f, log10_A=-15, gamma=4.33, lf0=-8.5, kappa=10/3, beta=0.5):
-    df = np.diff(np.concatenate((np.array([0]), f[::2])))
-    hcf = (10**log10_A * (f / const.fyr) ** ((3-gamma) / 2) /
-           (1 + (10**lf0 / f) ** kappa) ** beta)
-    return hcf**2/12/np.pi**2/f**3*np.repeat(df, 2)
-
-
 # overlap reduction functions
 
 @function
@@ -1170,7 +972,7 @@ def createfourierdesignmatrix_physicalephem(toas, planetssb, pos_t,
                     c = np.zeros(6)
                     c[i] = dpar
 
-                    #Fl.append(physical_ephem_delay(toas, planetssb, pos_t,
+                    # Fl.append(physical_ephem_delay(toas, planetssb, pos_t,
                     #                               **{parname: c}, **oa)/dpar)
                     kwarg_dict = {parname: c}
                     kwarg_dict.update(oa)

--- a/enterprise/signals/utils.py
+++ b/enterprise/signals/utils.py
@@ -20,12 +20,9 @@ from pkg_resources import resource_filename, Requirement
 import enterprise
 import enterprise.constants as const
 from enterprise.signals.parameter import function
-from enterprise.signals.gp_priors import powerlaw, turnover
-from enterprise.signals.gp_bases import (createfourierdesignmatrix_red,
-                                         createfourierdesignmatrix_dm,
-                                         createfourierdesignmatrix_env,
-                                         createfourierdesignmatrix_ephem,
-                                         createfourierdesignmatrix_eph)
+from enterprise.signals.gp_priors import powerlaw, turnover  # noqa: F401
+from enterprise.signals.gp_bases import *  # noqa: F401, F403
+
 
 try:
     from sksparse.cholmod import cholesky

--- a/tests/test_gp_priors.py
+++ b/tests/test_gp_priors.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+test_gp_priors
+----------------------------------
+
+Tests for GP priors and bases.
+"""
+
+
+import unittest
+import numpy as np
+
+from tests.enterprise_test_data import datadir
+from enterprise.pulsar import Pulsar
+from enterprise.signals import parameter
+from enterprise.signals import gp_signals
+from enterprise.signals import gp_priors
+from enterprise.signals import gp_bases
+import scipy.stats
+
+
+class TestGPSignals(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        """Setup the Pulsar object."""
+
+        # initialize Pulsar class
+        cls.psr = Pulsar(datadir + '/B1855+09_NANOGrav_9yv1.gls.par',
+                         datadir + '/B1855+09_NANOGrav_9yv1.tim')
+
+    def test_turnover_prior(self):
+        """Test that red noise signal returns correct values."""
+        # set up signal parameter
+        pr = gp_priors.turnover(log10_A=parameter.Uniform(-18,-12),
+                                gamma=parameter.Uniform(1,7),
+                                lf0=parameter.Uniform(-9,-7.5),
+                                kappa=parameter.Uniform(2.5,5),
+                                beta=parameter.Uniform(0.01,1),)
+        basis = gp_bases.createfourierdesignmatrix_red(nmodes=30)
+        rn = gp_signals.BasisGP(priorFunction=pr, basisFunction=basis,
+                                name='red_noise')
+        rnm = rn(self.psr)
+
+        # parameters
+        log10_A, gamma, lf0, kappa, beta = -14.5, 4.33, -8.5, 3, 0.5
+        params = {'B1855+09_red_noise_log10_A': log10_A,
+                  'B1855+09_red_noise_gamma': gamma,
+                  'B1855+09_red_noise_lf0': lf0,
+                  'B1855+09_red_noise_kappa': kappa,
+                  'B1855+09_red_noise_beta': beta}
+
+        # basis matrix test
+        F, f2 = gp_bases.createfourierdesignmatrix_red(self.psr.toas,
+                                                       nmodes=30)
+        msg = 'F matrix incorrect for turnover.'
+        assert np.allclose(F, rnm.get_basis(params)), msg
+
+        # spectrum test
+        phi = gp_priors.turnover(f2,
+                                 log10_A=log10_A,
+                                 gamma=gamma,
+                                 lf0=lf0,
+                                 kappa=kappa,
+                                 beta=beta)
+        msg = 'Spectrum incorrect for turnover.'
+        assert np.all(rnm.get_phi(params) == phi), msg
+
+        # inverse spectrum test
+        msg = 'Spectrum inverse incorrect for turnover.'
+        assert np.all(rnm.get_phiinv(params) == 1/phi), msg
+
+        # test shape
+        msg = 'F matrix shape incorrect'
+        assert rnm.get_basis(params).shape == F.shape, msg
+
+    def test_free_spec_prior(self):
+        """Test that red noise signal returns correct values."""
+        # set up signal parameter
+        pr = gp_priors.free_spectrum(log10_rho=parameter.Uniform(-10, -4,
+                                                                 size=30))
+        basis = gp_bases.createfourierdesignmatrix_red(nmodes=30)
+        rn = gp_signals.BasisGP(priorFunction=pr, basisFunction=basis,
+                                name='red_noise')
+        rnm = rn(self.psr)
+        # parameters
+        rhos = np.random.uniform(-10, -4, size=30)
+        params = {'B1855+09_red_noise_log10_rho': rhos}
+        # basis matrix test
+        F, f2 = gp_bases.createfourierdesignmatrix_red(self.psr.toas,
+                                                       nmodes=30)
+        msg = 'F matrix incorrect for free spectrum.'
+        assert np.allclose(F, rnm.get_basis(params)), msg
+
+        # spectrum test
+        phi = gp_priors.free_spectrum(f2, log10_rho=rhos)
+
+        msg = 'Spectrum incorrect for free spectrum.'
+        assert np.all(rnm.get_phi(params) == phi), msg
+
+        # inverse spectrum test
+        msg = 'Spectrum inverse incorrect for free spectrum.'
+        assert np.all(rnm.get_phiinv(params) == 1/phi), msg
+
+        # test shape
+        msg = 'F matrix shape incorrect'
+        assert rnm.get_basis(params).shape == F.shape, msg
+
+    def test_t_process_prior(self):
+        """Test that red noise signal returns correct values."""
+        # set up signal parameter
+        pr = gp_priors.t_process(log10_A=parameter.Uniform(-18,-12),
+                                 gamma=parameter.Uniform(1,7),
+                                 alphas=gp_priors.InvGamma(alpha=1, gamma=1,
+                                                           size=30))
+        basis = gp_bases.createfourierdesignmatrix_red(nmodes=30)
+        rn = gp_signals.BasisGP(priorFunction=pr, basisFunction=basis,
+                                name='red_noise')
+        rnm = rn(self.psr)
+        # parameters
+        alphas = scipy.stats.invgamma.rvs(1, scale=1, size=30)
+        log10_A, gamma = -15, 4.33
+        params = {'B1855+09_red_noise_log10_A': log10_A,
+                  'B1855+09_red_noise_gamma': gamma,
+                  'B1855+09_red_noise_alphas': alphas}
+        # basis matrix test
+        F, f2 = gp_bases.createfourierdesignmatrix_red(self.psr.toas,
+                                                       nmodes=30)
+        msg = 'F matrix incorrect for free spectrum.'
+        assert np.allclose(F, rnm.get_basis(params)), msg
+
+        # spectrum test
+        phi = gp_priors.t_process(f2, log10_A=log10_A, gamma=gamma,
+                                  alphas=alphas)
+
+        msg = 'Spectrum incorrect for free spectrum.'
+        assert np.all(rnm.get_phi(params) == phi), msg
+
+        # inverse spectrum test
+        msg = 'Spectrum inverse incorrect for free spectrum.'
+        assert np.all(rnm.get_phiinv(params) == 1/phi), msg
+
+        # test shape
+        msg = 'F matrix shape incorrect'
+        assert rnm.get_basis(params).shape == F.shape, msg
+
+    def test_adapt_t_process_prior(self):
+        """Test that red noise signal returns correct values."""
+        # set up signal parameter
+        pr = gp_priors.t_process_adapt(log10_A=parameter.Uniform(-18,-12),
+                                       gamma=parameter.Uniform(1,7),
+                                       alphas_adapt=gp_priors.InvGamma(),
+                                       nfreq=parameter.Uniform(5,25))
+        basis = gp_bases.createfourierdesignmatrix_red(nmodes=30)
+        rn = gp_signals.BasisGP(priorFunction=pr, basisFunction=basis,
+                                name='red_noise')
+        rnm = rn(self.psr)
+        # parameters
+        alphas = scipy.stats.invgamma.rvs(1, scale=1, size=1)
+        log10_A, gamma, nfreq = -15, 4.33, 12
+        params = {'B1855+09_red_noise_log10_A': log10_A,
+                  'B1855+09_red_noise_gamma': gamma,
+                  'B1855+09_red_noise_alphas_adapt': alphas,
+                  'B1855+09_red_noise_nfreq': nfreq}
+        # basis matrix test
+        F, f2 = gp_bases.createfourierdesignmatrix_red(self.psr.toas,
+                                                       nmodes=30)
+        msg = 'F matrix incorrect for free spectrum.'
+        assert np.allclose(F, rnm.get_basis(params)), msg
+
+        # spectrum test
+        phi = gp_priors.t_process_adapt(f2, log10_A=log10_A, gamma=gamma,
+                                        alphas_adapt=alphas, nfreq=nfreq)
+
+        msg = 'Spectrum incorrect for free spectrum.'
+        assert np.all(rnm.get_phi(params) == phi), msg
+
+        # inverse spectrum test
+        msg = 'Spectrum inverse incorrect for free spectrum.'
+        assert np.all(rnm.get_phiinv(params) == 1/phi), msg
+
+        # test shape
+        msg = 'F matrix shape incorrect'
+        assert rnm.get_basis(params).shape == F.shape, msg
+
+    def test_turnover_knee_prior(self):
+        """Test that red noise signal returns correct values."""
+        # set up signal parameter
+        pr = gp_priors.turnover_knee(log10_A=parameter.Uniform(-18,-12),
+                                     gamma=parameter.Uniform(1,7),
+                                     lfb=parameter.Uniform(-9,-7.5),
+                                     lfk=parameter.Uniform(-9,-7.5),
+                                     kappa=parameter.Uniform(2.5,5),
+                                     delta=parameter.Uniform(0.01,1),)
+        basis = gp_bases.createfourierdesignmatrix_red(nmodes=30)
+        rn = gp_signals.BasisGP(priorFunction=pr, basisFunction=basis,
+                                name='red_noise')
+        rnm = rn(self.psr)
+
+        # parameters
+        log10_A, gamma, lfb = -14.5, 4.33, -8.5
+        lfk, kappa, delta = -8.5, 3, 0.5
+        params = {'B1855+09_red_noise_log10_A': log10_A,
+                  'B1855+09_red_noise_gamma': gamma,
+                  'B1855+09_red_noise_lfb': lfb,
+                  'B1855+09_red_noise_lfk': lfk,
+                  'B1855+09_red_noise_kappa': kappa,
+                  'B1855+09_red_noise_delta': delta}
+
+        # basis matrix test
+        F, f2 = gp_bases.createfourierdesignmatrix_red(self.psr.toas,
+                                                       nmodes=30)
+        msg = 'F matrix incorrect for turnover.'
+        assert np.allclose(F, rnm.get_basis(params)), msg
+
+        # spectrum test
+        phi = gp_priors.turnover_knee(f2,
+                                      log10_A=log10_A,
+                                      gamma=gamma,
+                                      lfb=lfb,
+                                      lfk=lfk,
+                                      kappa=kappa,
+                                      delta=delta)
+        msg = 'Spectrum incorrect for turnover.'
+        assert np.all(rnm.get_phi(params) == phi), msg
+
+        # inverse spectrum test
+        msg = 'Spectrum inverse incorrect for turnover.'
+        assert np.all(rnm.get_phiinv(params) == 1/phi), msg
+
+        # test shape
+        msg = 'F matrix shape incorrect'
+        assert rnm.get_basis(params).shape == F.shape, msg
+
+    def test_broken_powerlaw_prior(self):
+        """Test that red noise signal returns correct values."""
+        # set up signal parameter
+        pr = gp_priors.broken_powerlaw(log10_A=parameter.Uniform(-18,-12),
+                                       gamma=parameter.Uniform(1,7),
+                                       log10_fb=parameter.Uniform(-9,-7.5),
+                                       kappa=parameter.Uniform(0.1,1.0),
+                                       delta=parameter.Uniform(0.01,1),)
+        basis = gp_bases.createfourierdesignmatrix_red(nmodes=30)
+        rn = gp_signals.BasisGP(priorFunction=pr, basisFunction=basis,
+                                name='red_noise')
+        rnm = rn(self.psr)
+
+        # parameters
+        log10_A, gamma, log10_fb, kappa, delta = -14.5, 4.33, -8.5, 1, 0.5
+        params = {'B1855+09_red_noise_log10_A': log10_A,
+                  'B1855+09_red_noise_gamma': gamma,
+                  'B1855+09_red_noise_log10_fb': log10_fb,
+                  'B1855+09_red_noise_kappa': kappa,
+                  'B1855+09_red_noise_delta': delta}
+
+        # basis matrix test
+        F, f2 = gp_bases.createfourierdesignmatrix_red(self.psr.toas,
+                                                       nmodes=30)
+        msg = 'F matrix incorrect for turnover.'
+        assert np.allclose(F, rnm.get_basis(params)), msg
+
+        # spectrum test
+        phi = gp_priors.broken_powerlaw(f2,
+                                        log10_A=log10_A,
+                                        gamma=gamma,
+                                        log10_fb=log10_fb,
+                                        kappa=kappa,
+                                        delta=delta)
+        msg = 'Spectrum incorrect for turnover.'
+        assert np.all(rnm.get_phi(params) == phi), msg
+
+        # inverse spectrum test
+        msg = 'Spectrum inverse incorrect for turnover.'
+        assert np.all(rnm.get_phiinv(params) == 1/phi), msg
+
+        # test shape
+        msg = 'F matrix shape incorrect'
+        assert rnm.get_basis(params).shape == F.shape, msg
+
+    def test_powerlaw_genmodes_prior(self):
+        """Test that red noise signal returns correct values."""
+        # set up signal parameter
+        pr = gp_priors.powerlaw_genmodes(log10_A=parameter.Uniform(-18,-12),
+                                         gamma=parameter.Uniform(1,7))
+        basis = gp_bases.createfourierdesignmatrix_chromatic(nmodes=30)
+        rn = gp_signals.BasisGP(priorFunction=pr, basisFunction=basis,
+                                name='red_noise')
+        rnm = rn(self.psr)
+
+        # parameters
+        log10_A, gamma = -14.5, 4.33
+        params = {'B1855+09_red_noise_log10_A': log10_A,
+                  'B1855+09_red_noise_gamma': gamma}
+
+        # basis matrix test
+        F, f2 = gp_bases.createfourierdesignmatrix_chromatic(self.psr.toas,
+                                                             self.psr.freqs,
+                                                             nmodes=30)
+        msg = 'F matrix incorrect for turnover.'
+        assert np.allclose(F, rnm.get_basis(params)), msg
+
+        # spectrum test
+        phi = gp_priors.powerlaw_genmodes(f2,
+                                          log10_A=log10_A,
+                                          gamma=gamma)
+        msg = 'Spectrum incorrect for turnover.'
+        assert np.all(rnm.get_phi(params) == phi), msg
+
+        # inverse spectrum test
+        msg = 'Spectrum inverse incorrect for turnover.'
+        assert np.all(rnm.get_phiinv(params) == 1/phi), msg
+
+        # test shape
+        msg = 'F matrix shape incorrect'
+        assert rnm.get_basis(params).shape == F.shape, msg


### PR DESCRIPTION
This adds a few of the functions from [`enterprise_extensions`](https://github.com/nanograv/enterprise_extensions/) into the base package. It also reorganizes the Gaussian process functions out of `utils.py` and into their own sub modules. Backwards compatibility is retained by calling the functions explicitly in the namespace of `utils`, as suggested by @vallis. 