### PR TITLE
removed global variables

### DIFF
--- a/enterprise/constants.py
+++ b/enterprise/constants.py
@@ -43,3 +43,9 @@ erg = sc.erg
 
 # other things
 DM_K = 2.41e-16  # for DM variation design matrix
+
+# relative angle between the Earth's ecliptic and the galactic equator
+e_ecl = 23.43704 * np.pi / 180.0
+
+# unit vector pointing in direction of angle between Earth's ecliptic and the galactic equator
+M_ecl = np.array([[1.0, 0.0, 0.0], [0.0, np.cos(e_ecl), -np.sin(e_ecl)], [0.0, np.sin(e_ecl), np.cos(e_ecl)]])

--- a/enterprise/signals/utils.py
+++ b/enterprise/signals/utils.py
@@ -252,10 +252,6 @@ def make_ecc_interpolant():
     return interp1d(fil[:, 0], fil[:, 1])
 
 
-# get interpolant for eccentric binaries
-ecc_interp = make_ecc_interpolant()
-
-
 def get_edot(F, mc, e):
 
     """
@@ -809,10 +805,6 @@ def tm_prior(weights):
 
 # Physical ephemeris model utility functions
 
-t_offset = 55197.0
-e_ecl = 23.43704 * np.pi / 180.0
-M_ecl = np.array([[1.0, 0.0, 0.0], [0.0, np.cos(e_ecl), -np.sin(e_ecl)], [0.0, np.sin(e_ecl), np.cos(e_ecl)]])
-
 
 def get_planet_orbital_elements(model="setIII"):
     """Grab physical ephemeris model files"""
@@ -829,6 +821,9 @@ def ecl2eq_vec(x):
     """
     Rotate (n,3) vector time series from ecliptic to equatorial.
     """
+    e_ecl = 23.43704 * np.pi / 180.0
+    M_ecl = np.array([[1.0, 0.0, 0.0], [0.0, np.cos(e_ecl), -np.sin(e_ecl)],
+                     [0.0, np.sin(e_ecl), np.cos(e_ecl)]])
     return np.einsum("jk,ik->ij", M_ecl, x)
 
 
@@ -836,6 +831,9 @@ def eq2ecl_vec(x):
     """
     Rotate (n,3) vector time series from equatorial to ecliptic.
     """
+    e_ecl = 23.43704 * np.pi / 180.0
+    M_ecl = np.array([[1.0, 0.0, 0.0], [0.0, np.cos(e_ecl), -np.sin(e_ecl)],
+                     [0.0, np.sin(e_ecl), np.cos(e_ecl)]])
     return np.einsum("kj,ik->ij", M_ecl, x)
 
 
@@ -880,6 +878,8 @@ def ss_framerotate(mjd, planet, x, y, z, dz, offset=None, equatorial=False):
     dz. The rate has units of rad/year, and is referred
     to offset 2010/1/1. dates must be given in MJD.
     """
+    t_offset = 55197.0
+
     if equatorial:
         planet = eq2ecl_vec(planet)
 

--- a/enterprise/signals/utils.py
+++ b/enterprise/signals/utils.py
@@ -821,9 +821,7 @@ def ecl2eq_vec(x):
     """
     Rotate (n,3) vector time series from ecliptic to equatorial.
     """
-    e_ecl = 23.43704 * np.pi / 180.0
-    M_ecl = np.array([[1.0, 0.0, 0.0], [0.0, np.cos(e_ecl), -np.sin(e_ecl)],
-                     [0.0, np.sin(e_ecl), np.cos(e_ecl)]])
+    M_ecl = const.M_ecl
     return np.einsum("jk,ik->ij", M_ecl, x)
 
 
@@ -831,9 +829,7 @@ def eq2ecl_vec(x):
     """
     Rotate (n,3) vector time series from equatorial to ecliptic.
     """
-    e_ecl = 23.43704 * np.pi / 180.0
-    M_ecl = np.array([[1.0, 0.0, 0.0], [0.0, np.cos(e_ecl), -np.sin(e_ecl)],
-                     [0.0, np.sin(e_ecl), np.cos(e_ecl)]])
+    M_ecl = const.M_ecl
     return np.einsum("kj,ik->ij", M_ecl, x)
 
 
@@ -878,7 +874,7 @@ def ss_framerotate(mjd, planet, x, y, z, dz, offset=None, equatorial=False):
     dz. The rate has units of rad/year, and is referred
     to offset 2010/1/1. dates must be given in MJD.
     """
-    t_offset = 55197.0
+    t_offset = 55197.0  # MJD 2010/01/01
 
     if equatorial:
         planet = eq2ecl_vec(planet)


### PR DESCRIPTION
4 variables outside functions removed from `enterprise.signals.utils`. `Pulsar` class in `enterprise.pulsar` should now load without `libstempo` installed.