### PR TITLE
coverage output in xml

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,0 +1,27 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "75...100"
+  status:
+    default:
+      # basic
+        target: 50%
+        #threshold: 0%
+    project: on
+    patch: on
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: no

--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -7,11 +7,13 @@ coverage:
   range: "75...100"
   status:
     project:
-      target: 85%
-      threshold: 6%
+      default:
+        target: 85%
+        threshold: 6%
     patch:
-      target: auto
-      threshold: 6%
+      default:
+        target: auto
+        threshold: 6%
 
 parsers:
   gcov:

--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -6,12 +6,12 @@ coverage:
   round: down
   range: "75...100"
   status:
-    project: on
-      target: 50%
-      #threshold: 0%
-    patch: off
+    project:
+      target: 85%
+      threshold: 6%
+    patch:
       target: auto
-      #threshold: 0%
+      threshold: 6%
 
 parsers:
   gcov:

--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -6,12 +6,12 @@ coverage:
   round: down
   range: "75...100"
   status:
-    default:
-      # basic
-        target: 50%
-        #threshold: 0%
     project: on
-    patch: on
+      target: 50%
+      #threshold: 0%
+    patch: off
+      target: auto
+      #threshold: 0%
 
 parsers:
   gcov:

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -43,7 +43,7 @@ jobs:
         pip freeze
     - name: Run Tests and Lint
       run: |
-        pytest --cov=./ --cov-report=xml --cov-config=.coveragerc
+        pytest --cov-config=.coveragerc --cov=enterprise --cov-report=xml
         make lint
     - name: Codecov
       uses: codecov/codecov-action@v1


### PR DESCRIPTION
This should output the coverage report in the correct format in addition to using the .coveragerc to exclude testing scripts, etc. from the coverage report.