### PR TITLE
Attempting to turn off project and patch checks preventing merges

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -6,14 +6,8 @@ coverage:
   round: down
   range: "75...100"
   status:
-    project:
-      default:
-        target: 85%
-        threshold: 6%
-    patch:
-      default:
-        target: auto
-        threshold: 6%
+    project: off
+    patch: off
 
 parsers:
   gcov:


### PR DESCRIPTION
Since I'm not really sure why pull requests keep stalling with a `Expected -- Waiting for status to be reported` error on the Codecov steps, this should turn off the coverage checks, but still upload the coverage.
![Example_Stalling](https://user-images.githubusercontent.com/43755708/106057377-e6ab3f00-60bd-11eb-822b-ab06f88cc385.png)
