### PR TITLE
Add .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF
+formats:
+   - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+   version: 3.7
+   install:
+   - requirements: requirements_dev.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,5 @@
 # .readthedocs.yaml
-# Read the Docs configuration file.
+# Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 # Required

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,5 @@
 # .readthedocs.yaml
-# Read the Docs configuration file
+# Read the Docs configuration file.
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 # Required

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,22 +5,22 @@ Welcome to enterprise's documentation!
 .. image:: https://img.shields.io/badge/GitHub-nanograv%2Fenterprise-blue.svg
         :target: https://github.com/nanograv/enterprise
 
-.. image:: https://img.shields.io/travis/nanograv/enterprise.svg
-        :target: https://travis-ci.org/nanograv/enterprise
-
+.. image:: https://github.com/nanograv/enterprise/workflows/CI-Tests/badge.svg
+        :target: https://github.com/nanograv/enterprise/actions
+        :alt: Build Status
 .. image:: https://readthedocs.org/projects/enterprise/badge/?version=latest
         :target: https://enterprise.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status
 
-.. image:: https://landscape.io/github/nanograv/enterprise/master/landscape.svg?style=flat
-   :target: https://landscape.io/github/nanograv/enterprise/master
-   :alt: Code Health
+.. image:: https://codecov.io/gh/nanograv/enterprise/branch/master/graph/badge.svg?token=YXSX3293VF
+        :target: https://codecov.io/gh/nanograv/enterprise
+        :alt: Test Coverage
+.. image:: https://img.shields.io/badge/python-3.6%2C%203.7%2C%203.8-blue.svg
+        :alt: Python Versions
 
-.. image:: https://coveralls.io/repos/github/nanograv/enterprise/badge.svg?branch=master
-    :target: https://coveralls.io/github/nanograv/enterprise?branch=master
-    
-.. image:: https://img.shields.io/badge/python-2.7%2C%203.5%2C%203.6-blue.svg
-
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4059815.svg
+       :target: https://doi.org/10.5281/zenodo.4059815
+       :alt: Zenodo DOI 4059815
 
 ENTERPRISE (Enhanced Numerical Toolbox Enabling a Robust PulsaR Inference SuitE)
 is a pulsar timing analysis code, aimed at noise analysis, gravitational-wave


### PR DESCRIPTION
This should fix the docs build and allow for configuration via git instead of on RTD directly. I added a setting in RTD to build the docs on PRs as well so we will know if we break docs. 

You can look at the docs built from this PR in the checks.