### PR TITLE
Optimize FourierBasis phase shifts (and fix caching bug)

### DIFF
--- a/enterprise/signals/gp_bases.py
+++ b/enterprise/signals/gp_bases.py
@@ -71,7 +71,7 @@ def createfourierdesignmatrix_red(
             # use the first toa to make a different seed for every pulsar
             seed = int(toas[0] / 17) + int(pseed)
             np.random.seed(seed)
-    
+
         ranphase = np.random.uniform(0.0, 2 * np.pi, nmodes)
     else:
         ranphase = np.zeros(nmodes)

--- a/enterprise/signals/gp_bases.py
+++ b/enterprise/signals/gp_bases.py
@@ -65,14 +65,16 @@ def createfourierdesignmatrix_red(
         else:
             f = np.linspace(fmin, fmax, nmodes)
 
-    # Use seed to make a repeatable random phase
-    if pseed is not None:
-        # Use the first toa to make a different seed for every pulsar
-        seed = int(toas[0] / 17) + pseed
-        np.random.seed(seed)
-
-    # add random phase shift to basis functions
-    ranphase = np.random.uniform(0.0, 2 * np.pi, nmodes) if pshift else np.zeros(nmodes)
+    # if requested, add random phase shift to basis functions
+    if pshift or pseed is not None:
+        if pseed is not None:
+            # use the first toa to make a different seed for every pulsar
+            seed = int(toas[0] / 17) + int(pseed)
+            np.random.seed(seed)
+    
+        ranphase = np.random.uniform(0.0, 2 * np.pi, nmodes)
+    else:
+        ranphase = np.zeros(nmodes)
 
     Ffreqs = np.repeat(f, 2)
 

--- a/enterprise/signals/gp_signals.py
+++ b/enterprise/signals/gp_signals.py
@@ -88,7 +88,10 @@ def BasisGP(
                 ret.extend([pp.name for pp in basis.params])
             return ret
 
-        @signal_base.cache_call("basis_params")
+        # since this function has side-effects, it can only be cached
+        # with limit=1, so it will run again if called with params different
+        # than the last time
+        @signal_base.cache_call("basis_params", limit=1)
         def _construct_basis(self, params={}):
             basis, self._labels = {}, {}
             for key, mask in zip(self._keys, self._masks):
@@ -325,7 +328,10 @@ def BasisCommonGP(priorFunction, basisFunction, orfFunction, coefficients=False,
             """Get any varying basis parameters."""
             return [pp.name for pp in self._bases.params]
 
-        @signal_base.cache_call("basis_params")
+        # since this function has side-effects, it can only be cached
+        # with limit=1, so it will run again if called with params different
+        # than the last time
+        @signal_base.cache_call("basis_params", limit=1)
         def _construct_basis(self, params={}):
             self._basis, self._labels = self._bases(params=params)
 
@@ -425,7 +431,10 @@ def FourierBasisCommonGP(
                 FourierBasisCommonGP._Tmin.append(psr.toas.min())
                 FourierBasisCommonGP._Tmax.append(psr.toas.max())
 
-        @signal_base.cache_call("basis_params")
+        # since this function has side-effects, it can only be cached
+        # with limit=1, so it will run again if called with params different
+        # than the last time
+        @signal_base.cache_call("basis_params", 1)
         def _construct_basis(self, params={}):
             span = Tspan if Tspan is not None else max(FourierBasisCommonGP._Tmax) - min(FourierBasisCommonGP._Tmin)
             self._basis, self._labels = self._bases(params=params, Tspan=span)

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -709,12 +709,12 @@ def SignalCollection(metasignals):  # noqa: C901
                     msg += "may not work correctly for this signal."
                     logger.error(msg)
 
-        def cache_clear(self):
-            for instance in [self] + self.signals:
-                kill = [attr for attr in instance.__dict__ if attr.startswith("_cache")]
-
-                for attr in kill:
-                    del instance.__dict__[attr]
+        # def cache_clear(self):
+        #     for instance in [self] + self.signals:
+        #         kill = [attr for attr in instance.__dict__ if attr.startswith("_cache")]
+        #
+        #        for attr in kill:
+        #            del instance.__dict__[attr]
 
         # a candidate for memoization
         @property

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -710,9 +710,9 @@ def SignalCollection(metasignals):  # noqa: C901
                     logger.error(msg)
 
         def cache_clear(self):
-            for instance in [self] + self.signals:    
-                kill = [attr for attr in instance.__dict__ if attr.startswith('_cache')]
-                
+            for instance in [self] + self.signals:
+                kill = [attr for attr in instance.__dict__ if attr.startswith("_cache")]
+
                 for attr in kill:
                     del instance.__dict__[attr]
 
@@ -922,8 +922,8 @@ def cache_call(attrs, limit=2):
                     _ = cache.pop(cache_list.pop(0), None)  # noqa: F841
             else:
                 msg = "Retrieving cache for {} in {}: {}".format(attrs, self.__class__, key)
-                logger.debug(msg)                
-            
+                logger.debug(msg)
+
             return cache[key]
 
         return wrapper

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -709,6 +709,13 @@ def SignalCollection(metasignals):  # noqa: C901
                     msg += "may not work correctly for this signal."
                     logger.error(msg)
 
+        def cache_clear(self):
+            for instance in [self] + self.signals:    
+                kill = [attr for attr in instance.__dict__ if attr.startswith('_cache')]
+                
+                for attr in kill:
+                    del instance.__dict__[attr]
+
         # a candidate for memoization
         @property
         def params(self):
@@ -743,35 +750,42 @@ def SignalCollection(metasignals):  # noqa: C901
             matrix to save computations when calling `get_basis` later.
             """
 
-            idx, Fmatlist, hashlist = {}, [], []
-            cc = 0
+            idx, hashlist, cc, nrow = {}, [], 0, None
             for signal in signals:
                 Fmat = signal.get_basis()
 
-                if Fmat is not None and not signal.basis_params:
-                    idx[signal] = []
+                if Fmat is not None:
+                    nrow = Fmat.shape[0]
 
-                    for i, column in enumerate(Fmat.T):
-                        colhash = hash(column.tostring())
+                    if not signal.basis_params:
+                        idx[signal] = []
 
-                        if signal.basis_combine and colhash in hashlist:
-                            j = hashlist.index(colhash)
-                            idx[signal].append(j)
-                        else:
-                            idx[signal].append(cc)
-                            Fmatlist.append(column)
-                            hashlist.append(colhash)
-                            cc += 1
-                elif Fmat is not None and signal.basis_params:
-                    nf = Fmat.shape[1]
-                    idx[signal] = list(range(cc, cc + nf))
-                    cc += nf
+                        for i, column in enumerate(Fmat.T):
+                            colhash = hash(column.tobytes())
+
+                            if signal.basis_combine and colhash in hashlist:
+                                # if we're combining the basis for this signal
+                                # and we have seen this column already, make a note
+                                # of where it was
+
+                                j = hashlist.index(colhash)
+                                idx[signal].append(j)
+                            else:
+                                # if we're not combining or we haven't seen it already
+                                # save the hash and make a note it's new
+
+                                hashlist.append(colhash)
+                                idx[signal].append(cc)
+                                cc += 1
+                    elif signal.basis_params:
+                        nf = Fmat.shape[1]
+                        idx[signal] = list(range(cc, cc + nf))
+                        cc += nf
 
             if not idx:
                 return {}, None
             else:
                 ncol = len(np.unique(sum(idx.values(), [])))
-                nrow = len(Fmatlist[0])
                 return ({key: np.array(idx[key]) for key in idx.keys()}, np.zeros((nrow, ncol)))
 
         # goofy way to cache _idx
@@ -796,7 +810,10 @@ def SignalCollection(metasignals):  # noqa: C901
         def get_detres(self, params):
             return self._residuals - self.get_delay(params)
 
-        @cache_call("basis_params")
+        # since this function has side-effects, it can only be cached
+        # with limit=1, so it will run again if called with params different
+        # than the last time
+        @cache_call("basis_params", limit=1)
         def get_basis(self, params={}):
             for signal in self._signals:
                 if signal in self._idx:
@@ -887,18 +904,26 @@ def cache_call(attrs, limit=2):
             if not hasattr(self, "_cache_" + func.__name__):
                 msg = "Create cache {} for signal {}".format(func.__name__, self.__class__)
                 logger.debug(msg)
+
                 setattr(self, "_cache_" + func.__name__, {})
                 setattr(self, "_cache_list_" + func.__name__, [])
+
             cache = getattr(self, "_cache_" + func.__name__)
             cache_list = getattr(self, "_cache_list_" + func.__name__)
 
             if key not in cache:
                 msg = "Setting cache for {} in {}: {}".format(attrs, self.__class__, key)
                 logger.debug(msg)
+
                 cache_list.append(key)
                 cache[key] = func(self, params)
+
                 if len(cache_list) > limit:
                     _ = cache.pop(cache_list.pop(0), None)  # noqa: F841
+            else:
+                msg = "Retrieving cache for {} in {}: {}".format(attrs, self.__class__, key)
+                logger.debug(msg)                
+            
             return cache[key]
 
         return wrapper

--- a/tests/test_gp_signals.py
+++ b/tests/test_gp_signals.py
@@ -530,6 +530,40 @@ class TestGPSignals(unittest.TestCase):
         msg = "M matrix shape incorrect"
         assert tm.get_basis(params).shape == self.psr.Mmat.shape, msg
 
+    def test_pshift_fourier(self):
+        """Test Fourier basis with prescribed phase shifts."""
+
+        # build a SignalCollection with timing model and red noise with phase shifts
+
+        Tspan = self.psr.toas.max() - self.psr.toas.min()
+        pl = utils.powerlaw(log10_A=parameter.Uniform(-18, -12), gamma=parameter.Uniform(0, 7))
+
+        ts = gp_signals.TimingModel()
+        rn = gp_signals.FourierBasisGP(pl, components=5, Tspan=Tspan, pseed=parameter.Uniform(0,32768))
+
+        s = ts + rn
+        m = s(self.psr)
+
+        b1 = m.signals[1].get_basis()
+        b2 = utils.createfourierdesignmatrix_red(nmodes=5, Tspan=Tspan)('')(self.psr.toas)[0]
+        msg = "Fourier bases incorrect (no phase shifts)"
+        assert np.all(b1 == b2), msg
+
+        b1 = m.signals[1].get_basis()
+        b2 = utils.createfourierdesignmatrix_red(nmodes=5, Tspan=Tspan, pseed=5)('')(self.psr.toas)[0]
+        msg = "Fourier bases incorrect (no-parameter call vs phase shift 5)"
+        assert not np.all(b1 == b2), msg
+
+        b1 = m.signals[1].get_basis(params={self.psr.name + '_red_noise_pseed': 5})
+        b2 = utils.createfourierdesignmatrix_red(nmodes=5, Tspan=Tspan, pseed=5)('')(self.psr.toas)[0]
+        msg = "Fourier bases incorrect (phase shift 5)"
+        assert np.all(b1 == b2), msg
+
+        b1 = m.signals[1].get_basis(params={self.psr.name + '_red_noise_pseed': 5})
+        b2 = utils.createfourierdesignmatrix_red(nmodes=5, Tspan=Tspan)('')(self.psr.toas)[0]
+        msg = "Fourier bases incorrect (phase-shift-5 call vs no phase shift)"
+        assert not np.all(b1 == b2), msg
+
     def test_gp_parameter(self):
         """Test GP basis model with parameterized basis."""
 

--- a/tests/test_gp_signals.py
+++ b/tests/test_gp_signals.py
@@ -539,28 +539,28 @@ class TestGPSignals(unittest.TestCase):
         pl = utils.powerlaw(log10_A=parameter.Uniform(-18, -12), gamma=parameter.Uniform(0, 7))
 
         ts = gp_signals.TimingModel()
-        rn = gp_signals.FourierBasisGP(pl, components=5, Tspan=Tspan, pseed=parameter.Uniform(0,32768))
+        rn = gp_signals.FourierBasisGP(pl, components=5, Tspan=Tspan, pseed=parameter.Uniform(0, 32768))
 
         s = ts + rn
         m = s(self.psr)
 
         b1 = m.signals[1].get_basis()
-        b2 = utils.createfourierdesignmatrix_red(nmodes=5, Tspan=Tspan)('')(self.psr.toas)[0]
+        b2 = utils.createfourierdesignmatrix_red(nmodes=5, Tspan=Tspan)("")(self.psr.toas)[0]
         msg = "Fourier bases incorrect (no phase shifts)"
         assert np.all(b1 == b2), msg
 
         b1 = m.signals[1].get_basis()
-        b2 = utils.createfourierdesignmatrix_red(nmodes=5, Tspan=Tspan, pseed=5)('')(self.psr.toas)[0]
+        b2 = utils.createfourierdesignmatrix_red(nmodes=5, Tspan=Tspan, pseed=5)("")(self.psr.toas)[0]
         msg = "Fourier bases incorrect (no-parameter call vs phase shift 5)"
         assert not np.all(b1 == b2), msg
 
-        b1 = m.signals[1].get_basis(params={self.psr.name + '_red_noise_pseed': 5})
-        b2 = utils.createfourierdesignmatrix_red(nmodes=5, Tspan=Tspan, pseed=5)('')(self.psr.toas)[0]
+        b1 = m.signals[1].get_basis(params={self.psr.name + "_red_noise_pseed": 5})
+        b2 = utils.createfourierdesignmatrix_red(nmodes=5, Tspan=Tspan, pseed=5)("")(self.psr.toas)[0]
         msg = "Fourier bases incorrect (phase shift 5)"
         assert np.all(b1 == b2), msg
 
-        b1 = m.signals[1].get_basis(params={self.psr.name + '_red_noise_pseed': 5})
-        b2 = utils.createfourierdesignmatrix_red(nmodes=5, Tspan=Tspan)('')(self.psr.toas)[0]
+        b1 = m.signals[1].get_basis(params={self.psr.name + "_red_noise_pseed": 5})
+        b2 = utils.createfourierdesignmatrix_red(nmodes=5, Tspan=Tspan)("")(self.psr.toas)[0]
         msg = "Fourier bases incorrect (phase-shift-5 call vs no phase shift)"
         assert not np.all(b1 == b2), msg
 


### PR DESCRIPTION
...by allowing the Parameter-ization of `pseed`, so that (e.g.) one can run a phase-shifted marginalized OS without making the PTA from scratch.

Required tweak in the handling of the seed and in the combination of redundant basis columns for multiple signals. Also required bugfix of caching mechanism: since the `_construct_basis()` methods have side effects, they can only be cached with limit=1, so they are rerun whenever the relevant params change from the last time.
