### PR TITLE
Fastloglikelihood

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# enterprise
+# fastloglikelihood branch of enterprise
+
+This branch is being developed by Aaron Johnson and Ken Olum to speed
+up the LogLikelihood computation as described by Xavier Siemens.
 
 ![PyPI](https://img.shields.io/pypi/v/enterprise-pulsar)
 ![Conda (channel only)](https://img.shields.io/conda/vn/conda-forge/enterprise-pulsar)

--- a/enterprise/signals/gp_signals.py
+++ b/enterprise/signals/gp_signals.py
@@ -231,6 +231,7 @@ def TimingModel(coefficients=False, name="linear_timing_model", use_svd=False, n
         signal_type = "basis"
         signal_name = "linear timing model"
         signal_id = name + "_svd" if use_svd else name
+        is_timing_model = True  # Say this is a timing model signal
 
         if coefficients:
 

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -342,7 +342,7 @@ class LogLikelihood(object):
     def __init__(self, pta, timer=time.process_time):
         self.pta = pta
         self.timer = timer
-        self.uses_1e40 = True   # Say that we include "infinite" terms
+        self.uses_1e40 = True  # Say that we include "infinite" terms
         self.cholesky_time = 0
         self.cholesky_calls = 0
 
@@ -466,9 +466,9 @@ class CompareLogLikelihood(object):
         likelihood = self.objects[i](xs, **kwargs)
         # If object used 1e40 as infinity and gave determinants using that,
         # remove them now.
-        if getattr(self.objects[i],"uses_1e40",False):
+        if getattr(self.objects[i], "uses_1e40", False):
             for collection in self.pta.pulsarmodels:
-                M = collection.get_basis_M() # Matrix with with timing model rows
+                M = collection.get_basis_M()  # Matrix with with timing model rows
                 likelihood += 0.5 * M.shape[1] * np.log(1e40)
         self.likelihoods[i] = likelihood
 

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -469,7 +469,10 @@ class CompareLogLikelihood(object):
         if getattr(self.objects[i], "uses_1e40", False):
             for collection in self.pta.pulsarmodels:
                 M = collection.get_basis_M()  # Matrix with with timing model rows
-                likelihood += 0.5 * M.shape[1] * np.log(1e40)
+                if M is not None:
+                    likelihood += 0.5 * M.shape[1] * np.log(1e40)
+                else:
+                    continue
         self.likelihoods[i] = likelihood
 
     def report(self):

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -1356,7 +1356,7 @@ def SignalCollection(metasignals):  # noqa: C901
 
         @cache_call("white_params")
         def get_MNM_logdet(self, params):
-            return self.get_MNM_cholesky().logdet()
+            return self.get_MNM_cholesky(params).logdet()
 
         @cache_call(["basis_params", "white_params"])
         def get_FNF(self, params):

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -211,7 +211,7 @@ Then for each set of parameters we compute:
 chi^-1
 det(chi)
 Sigma = chi^-1 + FDF
-Sigma^-1 and det(Sigma) FDr by Cholesky decomposition.
+Sigma^-1 and det(Sigma) by Cholesky decomposition.
 Now r C^-1 r = rDr - (FDr)^T Sigma^-1 FDr
 and det(C) = det(Sigma) det(chi) det(D)
 
@@ -1528,7 +1528,7 @@ def SignalCollection(metasignals):  # noqa: C901
             MNMMNF = self.get_MNMMNF(params)
             MNF = self.get_MNF(params)
             if MNF is None or MNMMNF is None:
-                return None
+                return self.get_FNF(params)
             return self.get_FNF(params) - np.tensordot(MNF, MNMMNF, (0, 0))  # FNF - MNF^T MNM^-1 MNF
 
         @cache_call(["basis_params", "white_params", "delay_params"])
@@ -1536,7 +1536,7 @@ def SignalCollection(metasignals):  # noqa: C901
             MNMMNF = self.get_MNMMNF(params)
             MNr = self.get_MNr(params)
             if MNr is None or MNMMNF is None:
-                return None
+                return self.get_FNr(params)
             return self.get_FNr(params) - np.tensordot(MNMMNF, MNr, (0, 0))  # FNr - MNF^T MNM^-1 MNr
 
         # Returns r^T D^-1 r and ln(det(D))

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -423,8 +423,13 @@ class LikelihoodsDifferentError(Exception):
 # and call all of them.  The return value is from the first object.
 class CompareLogLikelihood(object):
     def __init__(
-        self, pta, classes=(FastLogLikelihood, LogLikelihood), timer=time.process_time, tolerance=1e-3
-    ):  # Absolute tolerance for likelihood differences
+        self,
+        pta,
+        classes=(FastLogLikelihood, LogLikelihood),
+        timer=time.process_time,
+        tolerance=1e-3,  # Absolute tolerance for likelihood differences
+    ):
+        self.pta = pta
         self.constructors = classes
         self.n_objects = len(classes)
         self.likelihoods = np.zeros(self.n_objects)  # make list for later
@@ -461,6 +466,16 @@ class CompareLogLikelihood(object):
 
     def report(self):
         print("The maximum difference between any two loglikelihoods was {:.3g}".format(np.amax(self.max_differences)))
+        print(
+            "Running on",
+            platform.node(),
+            cpuinfo.get_cpu_info()["brand_raw"],
+            "with",
+            len(self.pta.pulsars),
+            "pulsars",
+            "using timer",
+            self.timer.__name__,
+        )
         for i in range(self.n_objects):
             print(self.constructors[i].__name__, end=" ")
             if self.counts[i] > 0:

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -221,7 +221,7 @@ If there are no model parameters, F and everything that depends on it will be No
 """
 
 
-class FastLogLikelihood(object):
+class LogLikelihood(object):
     def __init__(self, pta, cholesky_sparse=False, timer=time.process_time):
         self.pta = pta
         self._cholesky_sparse = cholesky_sparse
@@ -332,13 +332,13 @@ class FastLogLikelihood(object):
         return lnlike
 
 
-# This is just FastLogLikelihood with sparse_cholesky=True as the default
-class FastLogLikelihoodSparse(FastLogLikelihood):
+# This is just LogLikelihood with sparse_cholesky=True as the default
+class LogLikelihoodSparse(LogLikelihood):
     def __init__(self, pta, cholesky_sparse=True, **kwargs):
-        FastLogLikelihood.__init__(self, pta, cholesky_sparse=cholesky_sparse, **kwargs)
+        LogLikelihood.__init__(self, pta, cholesky_sparse=cholesky_sparse, **kwargs)
 
 
-class LogLikelihood(object):
+class OldLogLikelihood(object):
     def __init__(self, pta, timer=time.process_time):
         self.pta = pta
         self.timer = timer
@@ -426,7 +426,7 @@ class CompareLogLikelihood(object):
     def __init__(
         self,
         pta,
-        classes=(FastLogLikelihood, LogLikelihood),
+        classes=(LogLikelihood, OldLogLikelihood),
         timer=time.process_time,
         tolerance=1e-3,  # Absolute tolerance for likelihood differences
     ):
@@ -513,7 +513,7 @@ c.report()
 class PTA(object):
     # lnlikelihood is generally a class, but can be anything that can
     # be called with the pta object to return a likelihood object
-    def __init__(self, init, lnlikelihood=FastLogLikelihood):
+    def __init__(self, init, lnlikelihood=LogLikelihood):
         if isinstance(init, Sequence):
             self._signalcollections = list(init)
         else:

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -1041,13 +1041,17 @@ def SignalCollection(metasignals):  # noqa: C901
             MNMMNF = self.get_MNMMNF(params)
             MNr = self.get_MNr(params)
             return self.get_FNr(params) + np.tensordot(MNMMNF, MNr, (0,0))  # FNr + MNF^T MNM^-1 MNr
+
         # Returns r^T D^-1 r and ln(det(D))
         @cache_call(["white_params", "delay_params"])
         def get_rDr_logdet(self, params):
+            M = self.get_basis_M(params)
+            # infinity matrix determinant -- as seen in old calculation:
+            logdet_E = M.shape[1] * np.log(1e40)
             rNr, logdet_N = self.get_rNr_logdet(params)
             MNr = self.get_MNr(params)
             cf = self.get_MNM_cholesky(params)
-            return (rNr - np.dot(MNr, cf(MNr)), logdet_N + self.get_MNM_logdet(params))
+            return (rNr - np.dot(MNr, cf(MNr)), logdet_N + self.get_MNM_logdet(params) + logdet_E)
 
         # TO DO: cache how?
         def get_logsignalprior(self, params):

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -1453,7 +1453,7 @@ def SignalCollection(metasignals):  # noqa: C901
             res = self.get_detres(params)
             return Nvec.solve(res, left_array=M)
 
-        @cache_call(["basis_params", "delay_params"])
+        @cache_call(["basis_params", "white_params", "delay_params"])
         def get_FNr(self, params):
             F = self.get_basis_F(params)
             if F is None:

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -377,7 +377,7 @@ class LogLikelihood(object):
             start = self.timer()
             try:
                 cf = cholesky(Sigma)
-            except:
+            except CholmodError:
                 return -np.inf
 
             this_time = self.timer() - start

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -428,7 +428,7 @@ class CompareLogLikelihood(object):
         pta,
         classes=(LogLikelihood, OldLogLikelihood),
         timer=time.process_time,
-        tolerance=1e-3,  # Absolute tolerance for likelihood differences
+        tolerance=1e-2,  # Absolute tolerance for likelihood differences
     ):
         self.pta = pta
         self.constructors = classes

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -237,7 +237,7 @@ class FastLogLikelihood(object):
                 self.lnlikelihood0 += -0.5 * self.rDrs[ii][0] - 0.5 * self.rDrs[ii][1]
 
     # _make_Sigma definition or similar goes here
-    def _make_sigma(FDFs, chiinv):
+    def _make_sigma(self, FDFs, chiinv):
         return sps.block_diag(FDFs, "csc") + sps.csc_matrix(chiinv)
 
     def __call__(self, xs, chiinv_method="cliques"):

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -183,9 +183,9 @@ det(phi)
 Sigma = phi^-1 + TNT
 Sigma^-1 TNr and det(Sigma) by Cholesky decomposition
 (TNr)^T Sigma^-1 TNr
-Now r^T C^-1 r = rNr + (TNr)^T Sigma^-1 TNr
+Now r^T C^-1 r = rNr - (TNr)^T Sigma^-1 TNr
 and det(C) = det(Sigma) det(phi) det(N).
-lnlikelihood = (1/2)(rCr - ln det(C)).  We do not include the factor (2pi)^N_TOA
+lnlikelihood = -(1/2)(rCr + ln det(C)).  We do not include the factor (2pi)^N_TOA
 
 For the two step procedure, we define also:
 
@@ -202,7 +202,7 @@ r N^-1 r
 F^T N^-1 F
 M^T N^-1 F
 (MNM)^-1 MNF
-F^T D^-1 F = FNF + (MNF)^T (MNM)^-1 MNF
+F^T D^-1 F = FNF - (MNF)^T (MNM)^-1 MNF
 r^T D^-1 r = r N^-1 r  - (MNr)^T (MNM)^-1 MNr
 F^T D^-1 r = F^T N^-1 r - (MNMMNF)^T MNr
 det(D) = det(MNM) det(N).  We don't include the infinite det(E) here.
@@ -212,7 +212,7 @@ chi^-1
 det(chi)
 Sigma = chi^-1 + FDF
 Sigma^-1 and det(Sigma) FDr by Cholesky decomposition.
-Now r C^-1 r = rDr + (FDr)^T Sigma^-1 FDr
+Now r C^-1 r = rDr - (FDr)^T Sigma^-1 FDr
 and det(C) = det(Sigma) det(chi) det(D)
 
 If there are no timing parameters, M and everything that depends on it will be None, and then D = N.

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -461,7 +461,7 @@ class CompareLogLikelihood(object):
         self.max_differences = np.zeros((self.n_objects, self.n_objects))  # Differences between pairs of results
         self.times = np.zeros(self.n_objects)  # Time in each object
         self.counts = np.zeros(self.n_objects, dtype=int)  # Count of calls to each object
-        self.orders = tuple(itertools.permutations(list(range(self.n_objects)))) # Possible orders
+        self.orders = tuple(itertools.permutations(list(range(self.n_objects))))  # Possible orders
         self.order_pointer = 0  # Order to use next
         for object in self.objects:  # Reset timers in sub-objects
             object.cholesky_calls = object.cholesky_time = 0
@@ -469,7 +469,7 @@ class CompareLogLikelihood(object):
     def __call__(self, xs, **kwargs):
         # on jth call, go in order j,j+1...n-1, 0, 1, .. j-1.  See above
         order = self.orders[self.order_pointer]
-        self.order_pointer = (self.order_pointer + 1) % len(self.orders) # Ready for next
+        self.order_pointer = (self.order_pointer + 1) % len(self.orders)  # Ready for next
         for i in order:
             self.times[i] += timeit.timeit(lambda: self.call_object(i, xs, **kwargs), timer=self.timer, number=1)
             self.counts[i] += 1
@@ -520,8 +520,10 @@ class CompareLogLikelihood(object):
                 print("not called,", end=" ")
             if self.objects[i].cholesky_calls > 0:
                 print(
-                    "{:.2f} of this in a total of {} cholesky calls".format(1000 * self.objects[i].cholesky_time / self.counts[i], self.objects[i].cholesky_calls
-                ))
+                    "{:.2f} of this in a total of {} cholesky calls".format(
+                        1000 * self.objects[i].cholesky_time / self.counts[i], self.objects[i].cholesky_calls
+                    )
+                )
             else:
                 print("no cholesky calls")
 

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -1006,7 +1006,7 @@ def SignalCollection(metasignals):  # noqa: C901
             if F is None:
                 return None
             Nvec = self.get_ndiag(params)
-            return Nvec.solve(F, left_array=F)
+            return Nvec.solve(F, left_array=F)  # F^T N^{-1} F
 
         @cache_call(["basis_params", "white_params"])
         def get_MNF(self, params):
@@ -1015,7 +1015,7 @@ def SignalCollection(metasignals):  # noqa: C901
             if F is None or M is None:
                 return None
             Nvec = self.get_ndiag(params)
-            return Nvec.solve(F, left_array=M)
+            return Nvec.solve(F, left_array=M)  # M^T N^{-1} F
 
         @cache_call(["basis_params", "white_params"])
         def get_MNMMNF(self, params):
@@ -1034,13 +1034,13 @@ def SignalCollection(metasignals):  # noqa: C901
         def get_FDF(self, params):
             MNMMNF = self.get_MNMMNF(params)
             MNF = self.get_MNF(params)
-            return self.get_FNF(params) + np.tensordot(MNF, MNMMNF, (0,0)) # FNF + MNF^T MNM^-1 MNF
+            return self.get_FNF(params) - np.tensordot(MNF, MNMMNF, (0, 0))  # FNF + MNF^T MNM^-1 MNF
 
         @cache_call(["basis_params", "white_params", "delay_params"])
         def get_FDr(self, params):
             MNMMNF = self.get_MNMMNF(params)
             MNr = self.get_MNr(params)
-            return self.get_FNr(params) + np.tensordot(MNMMNF, MNr, (0,0))  # FNr + MNF^T MNM^-1 MNr
+            return self.get_FNr(params) - np.tensordot(MNMMNF, MNr, (0,0))  # FNr + MNF^T MNM^-1 MNr
 
         # Returns r^T D^-1 r and ln(det(D))
         @cache_call(["white_params", "delay_params"])

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -278,8 +278,6 @@ class FastLogLikelihood(object):
                     continue
 
                 chiinv, logdet_chi = pl
-                print(FDF)
-                print(chiinv)
                 Sigma = FDF + (np.diag(chiinv) if chiinv.ndim == 1 else chiinv)
 
                 try:

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -7,7 +7,19 @@ derived from these base classes.
 import time
 import timeit
 import platform
-import cpuinfo
+
+try:
+    import cpuinfo
+
+    def cpu_model():
+        return cpuinfo.get_cpu_info()["brand_raw"]
+
+
+except ModuleNotFoundError:
+
+    def cpu_model():
+        return "unknown CPU (for better info install cpuinfo)"
+
 
 import collections
 
@@ -502,7 +514,7 @@ class CompareLogLikelihood(object):
         print(
             "Running on",
             platform.node(),
-            cpuinfo.get_cpu_info()["brand_raw"],
+            cpu_model(),
             "with",
             len(self.pta.pulsars),
             "pulsars",

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -1325,7 +1325,7 @@ def SignalCollection(metasignals):  # noqa: C901
                 return None
             Nvec = self.get_ndiag(params)
             res = self.get_detres(params)
-            return Nvec.solve(res, left_array=T)
+            return Nvec.solve(res, left_array=M)
 
         @cache_call(["basis_params", "delay_params"])
         def get_FNr(self, params):

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -1430,10 +1430,10 @@ def SignalCollection(metasignals):  # noqa: C901
         def get_rDr_logdet(self, params):
             M = self.get_basis_M(params)
             # infinity matrix determinant -- as seen in old calculation:
-            logdet_E = M.shape[1] * np.log(1e40)
             rNr, logdet_N = self.get_rNr_logdet(params)
             if M is None:  # No model parameters so D=N
                 return (rNr, logdet_N)
+            logdet_E = M.shape[1] * np.log(1e40)
             MNr = self.get_MNr(params)
             cf = self.get_MNM_cholesky(params)
             return (rNr - np.dot(MNr, cf(MNr)), logdet_N + self.get_MNM_logdet(params) + logdet_E)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.0
+current_version = 3.1.1
 commit = False
 tag = False
 

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -219,7 +219,7 @@ class TestLikelihood(unittest.TestCase):
                 phigw = np.zeros(40)
             K = se_kernel(avetoas, log10_sigma=log10_sigmas[ii], log10_lam=log10_lams[ii])
             k = np.diag(np.concatenate((phi + phigw, np.ones(Mmat.shape[1]) * 1e40)))
-            count_1e40 += Mmat.shape[1] # Number of these "infinities"
+            count_1e40 += Mmat.shape[1]  # Number of these "infinities"
             if ik:
                 k = sl.block_diag(k, K)
             phis.append(k)
@@ -260,7 +260,6 @@ class TestLikelihood(unittest.TestCase):
             eloglike = pta.get_lnlikelihood(params, phiinv_method=mth)
             msg = "Incorrect like for npsr={}, phiinv={}".format(npsrs, mth)
             assert np.allclose(eloglike, loglike), msg
-
 
     def test_like_nocorr(self):
         """Test likelihood with no spatial correlations."""


### PR DESCRIPTION
Contains faster likelihood calculation as presented by Xavi at the Spring NANOGrav meeting.

This faster likelihood calculation:
1. Is 2 - 6 times faster in all gravitational wave background searches.
2. Leaves the wideband likelihood calculation the same
3. Is a little slower in the continuous wave searches
4. Matches to good accuracy with current likelihood calculation in all tested cases

This pull request adds new class methods to make this new class work, renames the current likelihood calculation class to OldLogLikelihood, and sets the LogLikelihood class containing the new calculation to be the default method of computation. Additionally, a CompareLogLikelihood class is added to allow quick comparison of speed and accuracy between the two methods of likelihood calculation.