### PR TITLE
Implementation of fast likelihood with MarginalizingTimingModel

### DIFF
--- a/enterprise/signals/gp_signals.py
+++ b/enterprise/signals/gp_signals.py
@@ -823,7 +823,9 @@ class MarginalizingNmat(object):
     def __radd__(self, other):
         return self.__add__(other)
 
-    @functools.cached_property
+    # in Python 3.8: @functools.cached_property
+    @property
+    @functools.lru_cache()
     def cf(self):
         MNM = sps.csc_matrix(self.Nmat.solve(self.Mmat, left_array=self.Mmat))
         return cholesky(MNM)

--- a/enterprise/signals/gp_signals.py
+++ b/enterprise/signals/gp_signals.py
@@ -9,6 +9,8 @@ import itertools
 import logging
 
 import numpy as np
+import scipy.sparse as sps
+from sksparse.cholmod import cholesky
 
 from enterprise.signals import parameter, selections, signal_base, utils
 from enterprise.signals.parameter import function
@@ -772,3 +774,91 @@ def WidebandTimingModel(
             return chi2
 
     return WidebandTimingModel
+
+
+def MarginalizingTimingModel(name="marginalizing_linear_timing_model"):
+    basisFunction = utils.normed_tm_basis()
+
+    class TimingModel(signal_base.Signal):
+        signal_type = "white noise"
+        signal_name = "marginalizing linear timing model"
+        signal_id = name
+
+        def __init__(self, psr):
+            super(TimingModel, self).__init__(psr)
+            self.name = self.psrname + "_" + self.signal_id
+
+            pname = "_".join([psr.name, name])
+            self.Mmat = basisFunction(pname, psr=psr)
+
+            self._params = {}
+
+        @property
+        def ndiag_params(self):
+            return []
+
+        # there are none, but to be general...
+        @signal_base.cache_call("ndiag_params")
+        def get_ndiag(self, params):
+            return MarginalizingNmat(self.Mmat()[0])
+
+    return TimingModel
+
+
+class MarginalizingNmat(object):
+    def __init__(self, Mmat, Nmat=0):
+        self.Mmat, self.Nmat = Mmat, Nmat
+        self.Mprior = Mmat.shape[1] * np.log(1e40)
+
+    def __add__(self, other):
+        if isinstance(other, MarginalizingNmat):
+            raise ValueError("Cannot combine multiple MarginalizingNmat objects.")
+        elif isinstance(other, np.ndarray) or hasattr(other, "solve"):
+            return MarginalizingNmat(self.Mmat, self.Nmat + other)
+        elif other == 0:
+            return self
+        else:
+            raise TypeError
+
+    def __radd__(self, other):
+        return self.__add__(other)
+
+    @functools.cached_property
+    def cf(self):
+        MNM = sps.csc_matrix(self.Nmat.solve(self.Mmat, left_array=self.Mmat))
+        return cholesky(MNM)
+
+    @signal_base.simplememobyid
+    def MNr(self, res):
+        return self.Nmat.solve(res, left_array=self.Mmat)
+
+    @signal_base.simplememobyid
+    def MNF(self, T):
+        return self.Nmat.solve(T, left_array=self.Mmat)
+
+    @signal_base.simplememobyid
+    def MNMMNF(self, T):
+        return self.cf(self.MNF(T))
+
+    # we're ignoring logdet = True for two-dimensional cases, but OK
+    def solve(self, right, left_array=None, logdet=False):
+        if right.ndim == 1 and left_array is right:
+            res = right
+
+            rNr, logdet_N = self.Nmat.solve(res, left_array=res, logdet=logdet)
+
+            MNr = self.MNr(res)
+            ret = rNr - np.dot(MNr, self.cf(MNr))
+            return (ret, logdet_N + self.cf.logdet() + self.Mprior) if logdet else ret
+        elif right.ndim == 1 and left_array is not None and left_array.ndim == 2:
+            res, T = right, left_array
+
+            TNr = self.Nmat.solve(res, left_array=T)
+            return TNr - np.tensordot(self.MNMMNF(T), self.MNr(res), (0, 0))
+        elif right.ndim == 2 and left_array is right:
+            T = right
+
+            TNT = self.Nmat.solve(T, left_array=T)
+            return TNT - np.tensordot(self.MNF(T), self.MNMMNF(T), (0, 0))
+        else:
+            raise ValueError("Incorrect arguments given to MarginalizingNmat.solve.")

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -79,8 +79,7 @@ class TestLikelihood(unittest.TestCase):
             Pulsar(datadir + "/J1909-3744_NANOGrav_9yv1.gls.par", datadir + "/J1909-3744_NANOGrav_9yv1.tim"),
         ]
 
-    def compute_like(self, npsrs=1, inc_corr=False, inc_kernel=False):
-
+    def compute_like(self, npsrs=1, inc_corr=False, inc_kernel=False, cholesky_sparse=True, marginalizing_tm=False):
         # get parameters from PAL2 style noise files
         params = get_noise_from_pal2(datadir + "/B1855+09_noise.txt")
         params2 = get_noise_from_pal2(datadir + "/J1909-3744_noise.txt")
@@ -115,7 +114,10 @@ class TestLikelihood(unittest.TestCase):
         orf = utils.hd_orf()
         crn = gp_signals.FourierBasisCommonGP(pl, orf, components=20, name="GW", Tspan=Tspan)
 
-        tm = gp_signals.TimingModel()
+        if marginalizing_tm:
+            tm = gp_signals.MarginalizingTimingModel()
+        else:
+            tm = gp_signals.TimingModel()
 
         log10_sigma = parameter.Uniform(-10, -5)
         log10_lam = parameter.Uniform(np.log10(86400), np.log10(1500 * 86400))
@@ -128,16 +130,21 @@ class TestLikelihood(unittest.TestCase):
             inc_kernel = [inc_kernel] * npsrs
 
         if inc_corr:
-            s = ef + eq + ec + rn + crn + tm
+            s = tm + ef + eq + ec + rn + crn
         else:
-            s = ef + eq + ec + rn + tm
+            s = tm + ef + eq + ec + rn
 
         models = []
         for ik, psr in zip(inc_kernel, psrs):
             snew = s + se if ik else s
             models.append(snew(psr))
 
-        pta = signal_base.PTA(models)
+        if cholesky_sparse:
+            like = signal_base.LogLikelihood
+        else:
+            like = signal_base.LogLikelihoodDenseCholesky
+
+        pta = signal_base.PTA(models, lnlikelihood=like)
 
         # set parameters
         pta.set_default_params(params)
@@ -253,7 +260,9 @@ class TestLikelihood(unittest.TestCase):
         method = ["partition", "sparse", "cliques"]
         for mth in method:
             eloglike = pta.get_lnlikelihood(params, phiinv_method=mth)
-            msg = "Incorrect like for npsr={}, phiinv={}".format(npsrs, mth)
+            msg = "Incorrect like for npsr={}, phiinv={}, csparse={}, mtm={}".format(
+                npsrs, mth, cholesky_sparse, marginalizing_tm
+            )
             assert np.allclose(eloglike, loglike), msg
 
     def test_like_nocorr(self):
@@ -263,7 +272,11 @@ class TestLikelihood(unittest.TestCase):
 
     def test_like_corr(self):
         """Test likelihood with spatial correlations."""
-        self.compute_like(npsrs=2, inc_corr=True)
+        for cholesky_sparse in [True, False]:
+            for marginalizing_tm in [True, False]:
+                self.compute_like(
+                    npsrs=2, inc_corr=True, cholesky_sparse=cholesky_sparse, marginalizing_tm=marginalizing_tm
+                )
 
     def test_like_nocorr_kernel(self):
         """Test likelihood with no spatial correlations and kernel."""
@@ -272,7 +285,8 @@ class TestLikelihood(unittest.TestCase):
 
     def test_like_corr_kernel(self):
         """Test likelihood with spatial correlations and kernel."""
-        self.compute_like(npsrs=2, inc_corr=True, inc_kernel=True)
+        self.compute_like(npsrs=2, inc_corr=True, inc_kernel=True, cholesky_sparse=True)
+        self.compute_like(npsrs=2, inc_corr=True, inc_kernel=True, cholesky_sparse=False)
 
     def test_like_nocorr_one_kernel(self):
         """Test likelihood with no spatial correlations and one kernel."""

--- a/tests/test_pulsar.py
+++ b/tests/test_pulsar.py
@@ -35,7 +35,7 @@ class TestPulsar(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        shutil.rmtree("pickle_dir")
+        shutil.rmtree("pickle_dir", ignore_errors=True)
 
     def test_residuals(self):
         """Check Residual shape."""


### PR DESCRIPTION
This PR implements the same algebra as #286, but confines it to a smart `MarginalizingTimingModel` object that does two things:

- Collects all other white-noise objects that would normally make up the N matrix, and stores their sum internally.
- When queried with `get_ndiag()`, returns a `MarginalizingNmat` object with a `solve()` method that returns (r^T D^-1 r), (T D^-1 r), (T D^-1 T^t) for the matrix D = N + M E M^T (with E formally infinite variance).

All operations are cached appropriately. This means that the TimingModel will not participate in the GP basis and Phi inversion. Note that `MarginalizingTimingModel` should be placed first when assembling a model.

The PR also modifies the standard Loglikelihood to accept a parameter `cholesky_sparse=False` that disables the sparse Cholesky of the combined Sigma matrix, and that caches the combined TNr and TNT. These steps are required to get the full benefits of MarginalizingTimingModel. 