### PR TITLE
Introduce experimental BasisCommonGP2 and FourierBasisCommonGP2 that accept selections

### DIFF
--- a/enterprise/pulsar.py
+++ b/enterprise/pulsar.py
@@ -284,6 +284,11 @@ class BasePulsar(object):
         """Return sun position vector at all timestamps"""
         return self._sunssb[self._isort, :]
 
+    @property
+    def telescope(self):
+        """Return telescope vector at all timestamps"""
+        return self._telescope[self._isort]
+
 
 class PintPulsar(BasePulsar):
     def __init__(self, toas, model, sort=True, drop_pintpsr=True, planets=True):
@@ -302,6 +307,7 @@ class PintPulsar(BasePulsar):
         self._toaerrs = np.array(toas.get_errors().to(u.s), dtype="float64")
         self._designmatrix = model.designmatrix(toas)[0]
         self._ssbfreqs = np.array(model.barycentric_radio_freq(toas), dtype="float64")
+        self._telescope = np.array(toas.get_obss())
 
         # fitted parameters
         self.fitpars = ["Offset"] + [par for par in model.params if not getattr(model, par).frozen]
@@ -423,6 +429,7 @@ class Tempo2Pulsar(BasePulsar):
         self._toaerrs = np.double(t2pulsar.toaerrs) * 1e-6
         self._designmatrix = np.double(t2pulsar.designmatrix())
         self._ssbfreqs = np.double(t2pulsar.ssbfreqs()) / 1e6
+        self._telescope = np.char.decode(t2pulsar.telescope(), encoding="ascii")
 
         # fitted parameters
         self.fitpars = ["Offset"] + [str(p) for p in t2pulsar.pars()]

--- a/enterprise/signals/gp_signals.py
+++ b/enterprise/signals/gp_signals.py
@@ -777,6 +777,7 @@ def WidebandTimingModel(
 # experimental versions of FourierBasisCommonGP and BasisCommonGP2 that support selections
 # note that Tspan must be provided to FourierBasisCommonGP2
 
+
 def FourierBasisCommonGP2(
     spectrum,
     orf,

--- a/enterprise/signals/gp_signals.py
+++ b/enterprise/signals/gp_signals.py
@@ -775,8 +775,7 @@ def WidebandTimingModel(
 
 
 # experimental versions of FourierBasisCommonGP and BasisCommonGP2 that support selections
-# note that Tspan must be provided to FourierBasisCommonGP2, and that
-
+# note that Tspan must be provided to FourierBasisCommonGP2
 
 def FourierBasisCommonGP2(
     spectrum,

--- a/enterprise/signals/gp_signals.py
+++ b/enterprise/signals/gp_signals.py
@@ -225,7 +225,7 @@ def TimingModel(coefficients=False, name="linear_timing_model", use_svd=False, n
         basis = utils.unnormed_tm_basis()
 
     prior = utils.tm_prior()
-    BaseClass = BasisGP(prior, basis, coefficients=coefficients, name=name)
+    BaseClass = BasisGP(prior, basis, coefficients=coefficients, name=name + "_svd" if use_svd else name)
 
     class TimingModel(BaseClass):
         signal_type = "basis"
@@ -772,3 +772,150 @@ def WidebandTimingModel(
             return chi2
 
     return WidebandTimingModel
+
+
+# experimental versions of FourierBasisCommonGP and BasisCommonGP2 that support selections
+# note that Tspan must be provided to FourierBasisCommonGP2, and that
+
+
+def FourierBasisCommonGP2(
+    spectrum,
+    orf,
+    coefficients=False,
+    combine=True,
+    selection=Selection(selections.no_selection),
+    components=20,
+    Tspan=None,
+    modes=None,
+    name="common_fourier",
+    pshift=False,
+    pseed=None,
+):
+    if coefficients:
+        raise NotImplementedError("Coefficients are not implemented yet.")
+
+    if Tspan is None:
+        raise ValueError("Please specify Tspan explicitly.")
+
+    basis = utils.createfourierdesignmatrix_red(nmodes=components, Tspan=Tspan, modes=modes, pshift=pshift, pseed=pseed)
+
+    return BasisCommonGP2(spectrum, basis, orf, combine=combine, selection=selection, name=name)
+
+
+def BasisCommonGP2(
+    priorFunction,
+    basisFunction,
+    orfFunction,
+    coefficients=False,
+    combine=True,
+    selection=Selection(selections.no_selection),
+    name="",
+):
+    if coefficients:
+        raise NotImplementedError("Coefficients are not implemented yet.")
+
+    class BasisCommonGP2(signal_base.CommonSignal):
+        signal_type = "common basis"
+        signal_name = "common"
+        signal_id = name
+
+        basis_combine = combine
+
+        def __init__(self, psr):
+            super(BasisCommonGP2, self).__init__(psr)
+            self.name = self.psrname + "_" + self.signal_id
+            self._do_selection(psr, priorFunction, basisFunction, orfFunction, selection)
+            self._psrpos = psr.pos
+
+        def _do_selection(self, psr, priorfn, basisfn, orffn, selection):
+            sel = selection(psr)
+
+            self._keys = sorted(sel.masks.keys())
+            self._masks = [sel.masks[key] for key in self._keys]
+            self._prior, self._bases, self._orf = {}, {}, {}
+            self._params, self._coefficients = {}, {}
+
+            for key, mask in zip(self._keys, self._masks):
+                pnames = [name, key]
+                pname = "_".join([n for n in pnames if n])
+
+                self._prior[key] = priorfn(pname, psr=psr)
+                self._bases[key] = basisfn(pname, psr=psr)
+                self._orf[key] = orffn(pname, psr=psr)
+
+                for par in itertools.chain(
+                    self._prior[key]._params.values(),
+                    self._bases[key]._params.values(),
+                    self._orf[key]._params.values(),
+                ):
+                    self._params[par.name] = par
+
+        @property
+        def basis_params(self):
+            """Get any varying basis parameters."""
+            ret = []
+            for basis in self._bases.values():
+                ret.extend([pp.name for pp in basis.params])
+            return ret
+
+        @signal_base.cache_call("basis_params", limit=1)
+        def _construct_basis(self, params={}):
+            basis, self._labels = {}, {}
+            for key, mask in zip(self._keys, self._masks):
+                basis[key], self._labels[key] = self._bases[key](params=params, mask=mask)
+
+            nc = sum(F.shape[1] for F in basis.values())
+            self._basis = np.zeros((len(self._masks[0]), nc))
+
+            # TODO: should this be defined here? it will cache phi
+            self._phi = KernelMatrix(nc)
+
+            self._slices = {}
+            nctot = 0
+            for key, mask in zip(self._keys, self._masks):
+                Fmat = basis[key]
+                nn = Fmat.shape[1]
+                self._basis[mask, nctot : nn + nctot] = Fmat
+                self._slices.update({key: slice(nctot, nn + nctot)})
+                nctot += nn
+
+        @property
+        def delay_params(self):
+            return []
+
+        def get_delay(self, params={}):
+            return 0
+
+        def get_basis(self, params={}):
+            self._construct_basis(params)
+
+            return self._basis
+
+        def get_phi(self, params):
+            self._construct_basis(params)
+
+            for key, slc in self._slices.items():
+                phislc = self._prior[key](self._labels[key], params=params)
+                orfslc = self._orf[key](self._psrpos, self._psrpos, params=params)
+
+                self._phi = self._phi.set(phislc * orfslc, slc)
+
+            return self._phi
+
+        @classmethod
+        def get_phicross(cls, signal1, signal2, params):
+            sl1, sl2 = [sum(slc.stop - slc.start for slc in signal._slices.values()) for signal in [signal1, signal2]]
+
+            phic = np.zeros((sl1, sl2))
+
+            for key in set(signal1._keys) & set(signal2._keys):
+                phislc = signal1._prior[key](signal1._labels[key], params=params)
+                orfslc = signal1._orf[key](signal1._psrpos, signal2._psrpos, params=params)
+
+                r1, r2 = [range(signal._slices[key].start, signal._slices[key].stop) for signal in [signal1, signal2]]
+
+                phic[r1, r2] = phislc * orfslc
+
+            return phic
+
+    return BasisCommonGP2

--- a/enterprise/signals/selections.py
+++ b/enterprise/signals/selections.py
@@ -118,6 +118,12 @@ def nanograv_backends(backend_flags):
     return {val: backend_flags == val for val in flagvals}
 
 
+def by_telescope(telescope):
+    """Selection function to split by telescope"""
+    telescopes = np.unique(telescope)
+    return {t: (telescope == t) for t in telescopes}
+
+
 def no_selection(toas):
     """Default selection with no splitting."""
     return {"": np.ones_like(toas, dtype=bool)}

--- a/enterprise/signals/white_signals.py
+++ b/enterprise/signals/white_signals.py
@@ -13,7 +13,7 @@ from enterprise.signals.selections import Selection
 
 
 def WhiteNoise(varianceFunction, selection=Selection(selections.no_selection), name=""):
-    """ Class factory for generic white noise signals."""
+    """Class factory for generic white noise signals."""
 
     class WhiteNoise(signal_base.Signal):
         signal_type = "white noise"

--- a/tests/test_gp_coefficients.py
+++ b/tests/test_gp_coefficients.py
@@ -53,7 +53,6 @@ class TestGPCoefficients(unittest.TestCase):
 
         # initialize Pulsar class
         cls.psr = Pulsar(datadir + "/B1855+09_NANOGrav_9yv1.gls.par", datadir + "/B1855+09_NANOGrav_9yv1.tim")
-
         cls.psr2 = Pulsar(datadir + "/B1937+21_NANOGrav_9yv1.gls.par", datadir + "/B1937+21_NANOGrav_9yv1.tim")
 
     def test_ephemeris(self):
@@ -282,6 +281,13 @@ class TestGPCoefficientsPint(TestGPCoefficients):
         cls.psr = Pulsar(
             datadir + "/B1855+09_NANOGrav_9yv1.gls.par",
             datadir + "/B1855+09_NANOGrav_9yv1.tim",
+            ephem="DE430",
+            timing_package="pint",
+        )
+
+        cls.psr2 = Pulsar(
+            datadir + "/B1937+21_NANOGrav_9yv1.gls.par",
+            datadir + "/B1937+21_NANOGrav_9yv1.tim",
             ephem="DE430",
             timing_package="pint",
         )

--- a/tests/test_gp_signals.py
+++ b/tests/test_gp_signals.py
@@ -15,7 +15,7 @@ import numpy as np
 import scipy.linalg as sl
 
 from enterprise.pulsar import Pulsar
-from enterprise.signals import gp_signals, parameter, selections, signal_base, utils
+from enterprise.signals import gp_signals, white_signals, parameter, selections, signal_base, utils
 from enterprise.signals.selections import Selection
 from tests.enterprise_test_data import datadir
 
@@ -685,6 +685,70 @@ class TestGPSignals(unittest.TestCase):
         msg = "Basis matrix shape incorrect size for combined signal."
         assert m.get_basis(params).shape == T.shape, msg
 
+    def test_gp_common_selection(self):
+        psr2 = Pulsar(datadir + "/B1937+21_NANOGrav_9yv1.gls.par", datadir + "/B1937+21_NANOGrav_9yv1.tim")
+
+        mn = white_signals.MeasurementNoise()
+
+        pl = utils.powerlaw(log10_A=parameter.Uniform(-20, -11), gamma=parameter.Uniform(0, 7))
+        orf = utils.hd_orf()
+        Tspan = max(self.psr.toas.max(), psr2.toas.max()) - min(self.psr.toas.min(), psr2.toas.min())
+
+        prn = gp_signals.FourierBasisGP(pl, components=1, Tspan=Tspan)
+        rn = gp_signals.FourierBasisCommonGP2(
+            pl, orf, selection=Selection(selections.by_telescope), components=1, Tspan=Tspan
+        )
+
+        model = mn + prn + rn
+        pta = signal_base.PTA([model(self.psr), model(psr2)])
+
+        telescopes = sorted(np.unique(psr2.telescope))
+
+        parnames = [par.name for par in pta.params]
+
+        msg = "Per-telescope common-noise parameters not in PTA"
+        assert all("common_fourier_{}_gamma".format(telescope) in parnames for telescope in telescopes), msg
+
+        p0 = parameter.sample(pta.params)
+
+        # will throw if there are problems
+        pta.get_lnlikelihood(params=p0, phiinv_method="sparse")
+        pta.get_lnprior(params=p0)
+
+        # should throw since phiinv_method is not 'sparse'
+        with self.assertRaises(NotImplementedError):
+            pta.get_lnlikelihood(params=p0)
+
+        msg = "Wrong nonzero element count in Phi matrices"
+        assert len(pta.pulsarmodels[0].get_phi(p0)) == 2, msg
+        assert len(pta.pulsarmodels[1].get_phi(p0)) == 6, msg
+
+        Phi = pta.get_phi(p0)
+        assert sum(sum(Phi != 0)) == 12, msg
+
+        # determine order of GP components in psr2
+        b0 = pta.pulsarmodels[1].get_basis()[:, 0] != 0
+        b1 = pta.pulsarmodels[1].get_basis()[:, 2] != 0
+        b2 = pta.pulsarmodels[1].get_basis()[:, 4] != 0
+
+        # a0 is arecibo/ao since telescopes is sorted
+        a0 = [np.all(b == (psr2.telescope == telescopes[0])) for b in [b0, b1, b2]]
+        a1 = [np.all(b == (psr2.telescope == telescopes[1])) for b in [b0, b1, b2]]
+
+        msg = "Wrong telescope masks for psr2"
+        assert sum(a0) == sum(a1) == 1, msg
+
+        # check cross-pulsar correlations are in the right place
+        i = len(pta.pulsarmodels[0].get_phi(p0)) + 2 * a0.index(True)
+        msg = "Wrong Phi cross terms"
+        assert Phi[0, i] != 0 and Phi[0, i] == Phi[i, 0], msg
+        assert Phi[1, i + 1] != 0 and Phi[1, i + 1] == Phi[i + 1, 1], msg
+
+        msg = "Discrepant Phi inverse"
+        assert np.allclose(
+            pta.get_phiinv(params=p0, method="sparse").toarray(), np.linalg.inv(pta.get_phi(params=p0))
+        ), msg
+
 
 class TestGPSignalsPint(TestGPSignals):
     @classmethod
@@ -698,3 +762,7 @@ class TestGPSignalsPint(TestGPSignals):
             ephem="DE430",
             timing_package="pint",
         )
+
+    # won't work because one PSR will have telescope == 'arecibo', the other 'ao'
+    def test_gp_common_selection(self):
+        pass

--- a/tests/test_pulsar.py
+++ b/tests/test_pulsar.py
@@ -35,7 +35,7 @@ class TestPulsar(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        shutil.rmtree("pickle_dir")
+        shutil.rmtree("pickle_dir", ignore_errors=True)
 
     def test_residuals(self):
         """Check Residual shape."""

--- a/tests/test_selections.py
+++ b/tests/test_selections.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+test_pulsar
+----------------------------------
+
+Tests for `signals/selections` module.
+"""
+
+import unittest
+import operator
+import functools
+
+import numpy as np
+
+from enterprise.pulsar import Pulsar
+import enterprise.signals.selections as selections
+from tests.enterprise_test_data import datadir
+
+
+class TestSelections(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Setup the Pulsar object."""
+
+        # initialize Pulsar class
+        cls.psr = Pulsar(datadir + "/B1937+21_NANOGrav_9yv1.gls.par", datadir + "/B1937+21_NANOGrav_9yv1.tim")
+
+    def test_selections(self):
+        # note: -B flag ('by_band') not currently represented in test data
+        for sel in ["cut_half", "by_frontend", "by_backend", "nanograv_backends", "by_telescope", "no_selection"]:
+
+            s = selections.Selection(getattr(selections, sel))(self.psr)
+
+            msg = "Selection mask count is incorrect for {}".format(sel)
+            assert sum(sum(mask) for mask in s.masks.values()) == len(self.psr.toas), msg
+
+            msg = "Selection mask coverage incomplete for {}".format(sel)
+            assert np.all(functools.reduce(operator.or_, s.masks.values())), msg
+
+            msg = "Selection mask not independent for {}".format(sel)
+            assert np.all(sum(mask for mask in s.masks.values()) == 1), msg
+
+
+class TestSelectionsPint(TestSelections):
+    @classmethod
+    def setUpClass(cls):
+        """Setup the Pulsar object."""
+
+        cls.psr = Pulsar(
+            datadir + "/B1937+21_NANOGrav_9yv1.gls.par", datadir + "/B1937+21_NANOGrav_9yv1.tim", timing_package="pint"
+        )


### PR DESCRIPTION
For instance, to implement independent correlated GPs on each telescope, one could do
```
rn = gp_signals.FourierBasisCommonGP2(pl, orf, selection=Selection(selections.by_telescope), Tspan=Tspan)
```
Note that it is currently necessary to set `Tspan`.

The PR also adds the method `telescope()` to pulsar, and `by_telescope()` to selections. 

