### PR TITLE
Fix regression in 1d4975: Pulsar.backend_flags need to be properly sorted

### DIFF
--- a/enterprise/pulsar.py
+++ b/enterprise/pulsar.py
@@ -302,11 +302,14 @@ class PintPulsar(BasePulsar):
         self._sort = sort
         self.planets = planets
         self.name = model.PSR.value
+
         if not drop_pintpsr:
             self.model = model
             self.pint_toas = toas
 
-        self._toas = np.array(toas.table["tdbld"], dtype="float64") * 86400
+        # these are TDB but not barycentered
+        # self._toas = np.array(toas.table["tdbld"], dtype="float64") * 86400
+        self._toas = np.array(model.get_barycentric_toas(toas).value, dtype="float64") * 86400
         # saving also stoas (e.g., for DMX comparisons)
         self._stoas = np.array(toas.get_mjds().value, dtype="float64") * 86400
         self._residuals = np.array(resids(toas, model).time_resids.to(u.s), dtype="float64")

--- a/enterprise/pulsar.py
+++ b/enterprise/pulsar.py
@@ -263,7 +263,7 @@ class BasePulsar(object):
             if flag in flagnames:
                 ret[:] = np.where(self._flags[flag] == "", ret, self._flags[flag])
 
-        return ret
+        return ret[self._isort]
 
     @property
     def theta(self):

--- a/tests/test_pulsar.py
+++ b/tests/test_pulsar.py
@@ -93,7 +93,7 @@ class TestPulsar(unittest.TestCase):
 
         # for the test pulsar, backend should be the same as 'f'
         msg = "Flag content or sorting incorrect"
-        assert np.all(self.psr._flags["f"][self.psr._isort] == self.backend_flags), msg
+        assert np.all(self.psr._flags["f"][self.psr._isort] == self.psr.backend_flags), msg
 
     def test_sky(self):
         """Check Sky location."""

--- a/tests/test_pulsar.py
+++ b/tests/test_pulsar.py
@@ -77,16 +77,23 @@ class TestPulsar(unittest.TestCase):
         assert self.psr.freqs.shape == (4005,), msg
 
     def test_flags(self):
-        """Check flags shape."""
+        """Check flags shape and content"""
 
         msg = "Flags shape incorrect"
         assert self.psr.flags["f"].shape == (4005,), msg
 
-    def test_backend_flags(self):
-        """Check backend_flags shape."""
+        msg = "Flag content or sorting incorrect"
+        assert np.all(self.psr._flags["fe"][self.psr._isort] == self.psr.flags["fe"]), msg
 
-        msg = "Backend Flags shape incorrect"
+    def test_backend_flags(self):
+        """Check backend_flags shape and content"""
+
+        msg = "Backend flags shape incorrect"
         assert self.psr.backend_flags.shape == (4005,), msg
+
+        # for the test pulsar, backend should be the same as 'f'
+        msg = "Flag content or sorting incorrect"
+        assert np.all(self.psr._flags["f"][self.psr._isort] == self.backend_flags), msg
 
     def test_sky(self):
         """Check Sky location."""


### PR DESCRIPTION
In commit 1d4975, I dropped a critical indexing step at line 266 in pulsar.py, which uses the toas sorting index to sort the backend_flags array. This resulted in scrambled selection masks when loading 12.5yr B1937 with PINT (but not with tempo2, which must do some sorting of its own). Aaron found this problem while testing PINT-BayesEphem. This one-line patch fixes the issue.