### PR TITLE
Make sure SignalCollection.get_basis() does not reuse numpy arrays to…

### DIFF
--- a/enterprise/signals/gp_signals.py
+++ b/enterprise/signals/gp_signals.py
@@ -338,6 +338,7 @@ def BasisCommonGP(priorFunction, basisFunction, orfFunction, coefficients=False,
             self._basis, self._labels = self._bases(params=params)
 
         if coefficients:
+
             def _get_coefficient_logprior(self, c, **params):
                 # MV: for correlated GPs, the prior needs to use
                 #     the coefficients for all GPs together;
@@ -370,6 +371,7 @@ def BasisCommonGP(priorFunction, basisFunction, orfFunction, coefficients=False,
                 return None
 
         else:
+
             @property
             def delay_params(self):
                 return []

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -871,13 +871,13 @@ def SignalCollection(metasignals):  # noqa: C901
         def get_basis(self, params={}):
             if self._Fmat is None:
                 return None
-            
+
             Fmat = np.zeros_like(self._Fmat)
-            
+
             for signal in self._signals:
                 if signal in self._idx:
                     Fmat[:, self._idx[signal]] = signal.get_basis(params)
-    
+
             return Fmat
 
         def get_phiinv(self, params):


### PR DESCRIPTION
… store new bases. Needed to reuse PTA objects in doing phase shifts by setting `pseed` to a Parameter.