### PR TITLE
Create combined EFAC + EQUAD noise object with tempo/tempo2 convention

### DIFF
--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -110,6 +110,9 @@ class Signal(object):
                 ret.append(p.name)
         return ret
 
+    def __repr__(self):
+        return "<Enterprise Signal object " + self.signal_id + "[" + ", ".join(p.name for p in self.params) + "]>"
+
     def get(self, parname, params={}):
         try:
             return params[self._params[parname].name]

--- a/enterprise/signals/white_signals.py
+++ b/enterprise/signals/white_signals.py
@@ -88,6 +88,28 @@ def EquadNoise(log10_equad=parameter.Uniform(-10, -5), selection=Selection(selec
     return EquadNoise
 
 
+@function
+def combined_ndiag(toaerrs, efac=1.0, log10_equad=-8):
+    return efac ** 2 * (toaerrs ** 2 + 10 ** (2 * log10_equad))
+
+
+def CombinedWhiteNoise(efac=parameter.Uniform(0.5, 1.5),
+                       log10_equad=parameter.Uniform(-10, -5),
+                       selection=Selection(selections.no_selection), name=""):
+
+    """Class factory for EFAC+EQUAD measurement noise
+    (with tempo/tempo2 parameter convention)."""
+
+    varianceFunction = combined_ndiag(efac=efac, log10_equad=log10_equad)
+    BaseClass = WhiteNoise(varianceFunction, selection=selection, name=name)
+
+    class CombinedWhiteNoise(BaseClass):
+        signal_name = "efacequad"
+        signal_id = "efacequad_" + name if name else "efacequad"
+
+    return CombinedWhiteNoise
+
+
 def EcorrKernelNoise(
     log10_ecorr=parameter.Uniform(-10, -5),
     selection=Selection(selections.no_selection),

--- a/enterprise/signals/white_signals.py
+++ b/enterprise/signals/white_signals.py
@@ -93,9 +93,12 @@ def combined_ndiag(toaerrs, efac=1.0, log10_equad=-8):
     return efac ** 2 * (toaerrs ** 2 + 10 ** (2 * log10_equad))
 
 
-def CombinedWhiteNoise(efac=parameter.Uniform(0.5, 1.5),
-                       log10_equad=parameter.Uniform(-10, -5),
-                       selection=Selection(selections.no_selection), name=""):
+def CombinedWhiteNoise(
+    efac=parameter.Uniform(0.5, 1.5),
+    log10_equad=parameter.Uniform(-10, -5),
+    selection=Selection(selections.no_selection),
+    name="",
+):
 
     """Class factory for EFAC+EQUAD measurement noise
     (with tempo/tempo2 parameter convention)."""

--- a/tests/test_hierarchical_parameter.py
+++ b/tests/test_hierarchical_parameter.py
@@ -125,15 +125,15 @@ class TestHierarchicalParameter(unittest.TestCase):
         def log10(A=10 ** -16):
             return np.log10(A)
 
-        fquad = white_signals.EquadNoise(
-            log10_equad=parameter.Function(log10, A=parameter.Uniform(10 ** -17, 10 ** -14))
+        fquad = white_signals.TNEquadNoise(
+            log10_tnequad=parameter.Function(log10, A=parameter.Uniform(10 ** -17, 10 ** -14))
         )
 
         fquad1 = fquad(self.psr)
 
-        repr_A = "[B1855+09_log10_equad_A:Uniform(pmin=1e-17, pmax=1e-14)]"
-        repr_B = "[B1855+09_log10_equad_A:Uniform(pmax=1e-14, pmin=1e-17)]"
+        repr_A = "[B1855+09_log10_tnequad_A:Uniform(pmin=1e-17, pmax=1e-14)]"
+        repr_B = "[B1855+09_log10_tnequad_A:Uniform(pmax=1e-14, pmin=1e-17)]"
         assert str(fquad1.params) == repr_A or str(fquad1.params) == repr_B
         assert np.allclose(
-            fquad1.get_ndiag(params={"B1855+09_log10_equad_A": 10 ** -14})[:3], np.array([1e-28, 1e-28, 1e-28])
+            fquad1.get_ndiag(params={"B1855+09_log10_tnequad_A": 10 ** -14})[:3], np.array([1e-28, 1e-28, 1e-28])
         )

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -46,7 +46,7 @@ def get_noise_from_pal2(noisefile):
             par = "efac"
             flag = ln[0].split("efac-")[-1]
         elif "equad" in line:
-            par = "log10_equad"
+            par = "log10_t2equad"
             flag = ln[0].split("equad-")[-1]
         elif "jitter_q" in line:
             par = "log10_ecorr"
@@ -104,8 +104,7 @@ class TestLikelihood(unittest.TestCase):
 
         selection = Selection(selections.by_backend)
 
-        ef = white_signals.MeasurementNoise(efac=efac, selection=selection)
-        eq = white_signals.EquadNoise(log10_equad=equad, selection=selection)
+        ms = white_signals.MeasurementNoise(efac=efac, log10_t2equad=equad, selection=selection)
         ec = white_signals.EcorrKernelNoise(log10_ecorr=ecorr, selection=selection)
 
         pl = utils.powerlaw(log10_A=log10_A, gamma=gamma)
@@ -130,9 +129,9 @@ class TestLikelihood(unittest.TestCase):
             inc_kernel = [inc_kernel] * npsrs
 
         if inc_corr:
-            s = tm + ef + eq + ec + rn + crn
+            s = tm + ms + ec + rn + crn
         else:
-            s = tm + ef + eq + ec + rn
+            s = tm + ms + ec + rn
 
         models = []
         for ik, psr in zip(inc_kernel, psrs):
@@ -181,8 +180,9 @@ class TestLikelihood(unittest.TestCase):
             nvec0 = np.zeros_like(psr.toas)
             for ct, flag in enumerate(flags):
                 ind = psr.backend_flags == flag
-                nvec0[ind] = efacs[ii][ct] ** 2 * psr.toaerrs[ind] ** 2
-                nvec0[ind] += 10 ** (2 * equads[ii][ct]) * np.ones(np.sum(ind))
+                nvec0[ind] = efacs[ii][ct] ** 2 * (
+                    psr.toaerrs[ind] ** 2 + 10 ** (2 * equads[ii][ct]) * np.ones(np.sum(ind))
+                )
 
             # get the basis
             bflags = psr.backend_flags

--- a/tests/test_set_parameter.py
+++ b/tests/test_set_parameter.py
@@ -31,7 +31,7 @@ def get_noise_from_pal2(noisefile):
             par = "efac"
             flag = ln[0].split("efac-")[-1]
         elif "equad" in line:
-            par = "log10_equad"
+            par = "log10_t2equad"
             flag = ln[0].split("equad-")[-1]
         elif "jitter_q" in line:
             par = "log10_ecorr"
@@ -78,14 +78,13 @@ class TestSetParameters(unittest.TestCase):
 
         selection = Selection(selections.by_backend)
 
-        ef = white_signals.MeasurementNoise(efac=efac, selection=selection)
-        eq = white_signals.EquadNoise(log10_equad=equad, selection=selection)
+        ms = white_signals.MeasurementNoise(efac=efac, log10_t2equad=equad, selection=selection)
         ec = white_signals.EcorrKernelNoise(log10_ecorr=ecorr, selection=selection)
 
         pl = utils.powerlaw(log10_A=log10_A, gamma=gamma)
         rn = gp_signals.FourierBasisGP(pl)
 
-        s = ef + eq + ec + rn
+        s = ms + ec + rn
         m = s(self.psrs[0])
 
         # set parameters
@@ -103,8 +102,9 @@ class TestSetParameters(unittest.TestCase):
         nvec0 = np.zeros_like(self.psrs[0].toas)
         for ct, flag in enumerate(np.unique(flags)):
             ind = flag == self.psrs[0].backend_flags
-            nvec0[ind] = efacs[ct] ** 2 * self.psrs[0].toaerrs[ind] ** 2
-            nvec0[ind] += 10 ** (2 * equads[ct]) * np.ones(np.sum(ind))
+            nvec0[ind] = efacs[ct] ** 2 * (
+                self.psrs[0].toaerrs[ind] ** 2 + 10 ** (2 * equads[ct]) * np.ones(np.sum(ind))
+            )
 
         # get the basis
         bflags = self.psrs[0].backend_flags
@@ -181,14 +181,13 @@ class TestSetParameters(unittest.TestCase):
 
         selection = Selection(selections.by_backend)
 
-        ef = white_signals.MeasurementNoise(efac=efac, selection=selection)
-        eq = white_signals.EquadNoise(log10_equad=equad, selection=selection)
+        ms = white_signals.MeasurementNoise(efac=efac, log10_t2equad=equad, selection=selection)
         ec = white_signals.EcorrKernelNoise(log10_ecorr=ecorr, selection=selection)
 
         pl = utils.powerlaw(log10_A=log10_A, gamma=gamma)
         rn = gp_signals.FourierBasisGP(pl)
 
-        s = ef + eq + ec + rn
+        s = ms + ec + rn
         pta = s(self.psrs[0]) + s(self.psrs[1])
 
         # set parameters
@@ -210,8 +209,9 @@ class TestSetParameters(unittest.TestCase):
             nvec0 = np.zeros_like(psr.toas)
             for ct, flag in enumerate(flags):
                 ind = psr.backend_flags == flag
-                nvec0[ind] = efacs[ii][ct] ** 2 * psr.toaerrs[ind] ** 2
-                nvec0[ind] += 10 ** (2 * equads[ii][ct]) * np.ones(np.sum(ind))
+                nvec0[ind] = efacs[ii][ct] ** 2 * (
+                    psr.toaerrs[ind] ** 2 + 10 ** (2 * equads[ii][ct]) * np.ones(np.sum(ind))
+                )
 
             # get the basis
             bflags = psr.backend_flags

--- a/tests/test_white_signals.py
+++ b/tests/test_white_signals.py
@@ -106,39 +106,39 @@ class TestWhiteSignals(unittest.TestCase):
         msg = "EFAC covariance incorrect."
         assert np.all(efm.get_ndiag(params) == nvec0), msg
 
-    def test_equad(self):
-        """Test that equad signal returns correct covariance."""
+    def test_tnequad(self):
+        """Test that tnequad signal returns correct covariance."""
         # set up signal and parameters
-        equad = parameter.Uniform(-10, -5)
-        eq = white_signals.EquadNoise(log10_equad=equad)
+        tnequad = parameter.Uniform(-10, -5)
+        eq = white_signals.TNEquadNoise(log10_tnequad=tnequad)
         eqm = eq(self.psr)
 
         # parameters
-        equad = -6.4
-        params = {"B1855+09_log10_equad": equad}
+        tnequad = -6.4
+        params = {"B1855+09_log10_tnequad": tnequad}
 
         # correct value
-        nvec0 = 10 ** (2 * equad) * np.ones_like(self.psr.toas)
+        nvec0 = 10 ** (2 * tnequad) * np.ones_like(self.psr.toas)
 
         # test
-        msg = "EQUAD covariance incorrect."
+        msg = "TNEQUAD covariance incorrect."
         assert np.all(eqm.get_ndiag(params) == nvec0), msg
 
-    def test_equad_backend(self):
+    def test_tnequad_backend(self):
         """Test that backend-equad signal returns correct covariance."""
         # set up signal and parameters
-        equad = parameter.Uniform(-10, -5)
+        tnequad = parameter.Uniform(-10, -5)
         selection = Selection(selections.by_backend)
-        eq = white_signals.EquadNoise(log10_equad=equad, selection=selection)
+        eq = white_signals.TNEquadNoise(log10_tnequad=tnequad, selection=selection)
         eqm = eq(self.psr)
 
         # parameters
-        equads = [-6.1, -6.2, -6.3, -6.4]
+        tnequads = [-6.1, -6.2, -6.3, -6.4]
         params = {
-            "B1855+09_430_ASP_log10_equad": equads[0],
-            "B1855+09_430_PUPPI_log10_equad": equads[1],
-            "B1855+09_L-wide_ASP_log10_equad": equads[2],
-            "B1855+09_L-wide_PUPPI_log10_equad": equads[3],
+            "B1855+09_430_ASP_log10_tnequad": tnequads[0],
+            "B1855+09_430_PUPPI_log10_tnequad": tnequads[1],
+            "B1855+09_L-wide_ASP_log10_tnequad": tnequads[2],
+            "B1855+09_L-wide_PUPPI_log10_tnequad": tnequads[3],
         }
 
         # correct value
@@ -146,62 +146,62 @@ class TestWhiteSignals(unittest.TestCase):
         nvec0 = np.zeros_like(self.psr.toas)
         for ct, flag in enumerate(np.unique(flags)):
             ind = flag == self.psr.backend_flags
-            nvec0[ind] = 10 ** (2 * equads[ct]) * np.ones(np.sum(ind))
+            nvec0[ind] = 10 ** (2 * tnequads[ct]) * np.ones(np.sum(ind))
 
         # test
-        msg = "EQUAD covariance incorrect."
+        msg = "TNEQUAD covariance incorrect."
         assert np.all(eqm.get_ndiag(params) == nvec0), msg
 
-    def test_add_efac_equad(self):
-        """Test that addition of efac and equad signal returns
+    def test_add_efac_tnequad(self):
+        """Test that addition of efac and tnequad signal returns
         correct covariance.
         """
         # set up signals
         efac = parameter.Uniform(0.1, 5)
         ef = white_signals.MeasurementNoise(efac=efac)
-        equad = parameter.Uniform(-10, -5)
-        eq = white_signals.EquadNoise(log10_equad=equad)
+        tnequad = parameter.Uniform(-10, -5)
+        eq = white_signals.TNEquadNoise(log10_tnequad=tnequad)
         s = ef + eq
         m = s(self.psr)
 
         # set parameters
         efac = 1.5
-        equad = -6.4
-        params = {"B1855+09_efac": efac, "B1855+09_log10_equad": equad}
+        tnequad = -6.4
+        params = {"B1855+09_efac": efac, "B1855+09_log10_tnequad": tnequad}
 
         # correct value
         nvec0 = efac ** 2 * self.psr.toaerrs ** 2
-        nvec0 += 10 ** (2 * equad) * np.ones_like(self.psr.toas)
+        nvec0 += 10 ** (2 * tnequad) * np.ones_like(self.psr.toas)
 
         # test
-        msg = "EFAC/EQUAD covariance incorrect."
+        msg = "EFAC/TNEQUAD covariance incorrect."
         assert np.all(m.get_ndiag(params) == nvec0), msg
 
-    def test_add_efac_equad_backend(self):
-        """Test that addition of efac-backend and equad-backend signal returns
+    def test_add_efac_tnequad_backend(self):
+        """Test that addition of efac-backend and tnequad-backend signal returns
         correct covariance.
         """
         selection = Selection(selections.by_backend)
 
         efac = parameter.Uniform(0.1, 5)
-        equad = parameter.Uniform(-10, -5)
+        tnequad = parameter.Uniform(-10, -5)
         ef = white_signals.MeasurementNoise(efac=efac, selection=selection)
-        eq = white_signals.EquadNoise(log10_equad=equad, selection=selection)
+        eq = white_signals.TNEquadNoise(log10_tnequad=tnequad, selection=selection)
         s = ef + eq
         m = s(self.psr)
 
         # set parameters
         efacs = [1.3, 1.4, 1.5, 1.6]
-        equads = [-6.1, -6.2, -6.3, -6.4]
+        tnequads = [-6.1, -6.2, -6.3, -6.4]
         params = {
             "B1855+09_430_ASP_efac": efacs[0],
             "B1855+09_430_PUPPI_efac": efacs[1],
             "B1855+09_L-wide_ASP_efac": efacs[2],
             "B1855+09_L-wide_PUPPI_efac": efacs[3],
-            "B1855+09_430_ASP_log10_equad": equads[0],
-            "B1855+09_430_PUPPI_log10_equad": equads[1],
-            "B1855+09_L-wide_ASP_log10_equad": equads[2],
-            "B1855+09_L-wide_PUPPI_log10_equad": equads[3],
+            "B1855+09_430_ASP_log10_tnequad": tnequads[0],
+            "B1855+09_430_PUPPI_log10_tnequad": tnequads[1],
+            "B1855+09_L-wide_ASP_log10_tnequad": tnequads[2],
+            "B1855+09_L-wide_PUPPI_log10_tnequad": tnequads[3],
         }
 
         # correct value
@@ -210,46 +210,46 @@ class TestWhiteSignals(unittest.TestCase):
         for ct, flag in enumerate(np.unique(flags)):
             ind = flag == self.psr.backend_flags
             nvec0[ind] = efacs[ct] ** 2 * self.psr.toaerrs[ind] ** 2
-            nvec0[ind] += 10 ** (2 * equads[ct]) * np.ones(np.sum(ind))
+            nvec0[ind] += 10 ** (2 * tnequads[ct]) * np.ones(np.sum(ind))
 
         logdet = np.sum(np.log(nvec0))
 
         # test
-        msg = "EFAC/EQUAD covariance incorrect."
+        msg = "EFAC/TNEQUAD covariance incorrect."
         assert np.all(m.get_ndiag(params) == nvec0), msg
 
-        msg = "EFAC/EQUAD logdet incorrect."
+        msg = "EFAC/TNEQUAD logdet incorrect."
         N = m.get_ndiag(params)
         assert np.allclose(N.solve(self.psr.residuals, logdet=True)[1], logdet, rtol=1e-10), msg
 
-        msg = "EFAC/EQUAD D1 solve incorrect."
+        msg = "EFAC/TNEQUAD D1 solve incorrect."
         assert np.allclose(N.solve(self.psr.residuals), self.psr.residuals / nvec0, rtol=1e-10), msg
 
-        msg = "EFAC/EQUAD 1D1 solve incorrect."
+        msg = "EFAC/TNEQUAD 1D1 solve incorrect."
         assert np.allclose(
             N.solve(self.psr.residuals, left_array=self.psr.residuals),
             np.dot(self.psr.residuals / nvec0, self.psr.residuals),
             rtol=1e-10,
         ), msg
 
-        msg = "EFAC/EQUAD 2D1 solve incorrect."
+        msg = "EFAC/TNEQUAD 2D1 solve incorrect."
         T = self.psr.Mmat
         assert np.allclose(
             N.solve(self.psr.residuals, left_array=T), np.dot(T.T, self.psr.residuals / nvec0), rtol=1e-10
         ), msg
 
-        msg = "EFAC/EQUAD 2D2 solve incorrect."
+        msg = "EFAC/TNEQUAD 2D2 solve incorrect."
         assert np.allclose(N.solve(T, left_array=T), np.dot(T.T, T / nvec0[:, None]), rtol=1e-10), msg
 
     def test_efac_equad_combined_backend(self):
-        """Test that the combined EFAC + EQUAD noise (tempo2 definition)
+        """Test that the combined EFAC + EQUAD noise (tempo/tempo2/pint definition)
         returns the correct covariance.
         """
         selection = Selection(selections.by_backend)
 
         efac = parameter.Uniform(0.1, 5)
-        equad = parameter.Uniform(-10, -5)
-        efq = white_signals.CombinedWhiteNoise(efac=efac, log10_equad=equad, selection=selection)
+        t2equad = parameter.Uniform(-10, -5)
+        efq = white_signals.MeasurementNoise(efac=efac, log10_t2equad=t2equad, selection=selection)
         m = efq(self.psr)
 
         # set parameters
@@ -260,10 +260,10 @@ class TestWhiteSignals(unittest.TestCase):
             "B1855+09_430_PUPPI_efac": efacs[1],
             "B1855+09_L-wide_ASP_efac": efacs[2],
             "B1855+09_L-wide_PUPPI_efac": efacs[3],
-            "B1855+09_430_ASP_log10_equad": equads[0],
-            "B1855+09_430_PUPPI_log10_equad": equads[1],
-            "B1855+09_L-wide_ASP_log10_equad": equads[2],
-            "B1855+09_L-wide_PUPPI_log10_equad": equads[3],
+            "B1855+09_430_ASP_log10_t2equad": equads[0],
+            "B1855+09_430_PUPPI_log10_t2equad": equads[1],
+            "B1855+09_L-wide_ASP_log10_t2equad": equads[2],
+            "B1855+09_L-wide_PUPPI_log10_t2equad": equads[3],
         }
 
         # correct value

--- a/tests/test_white_signals.py
+++ b/tests/test_white_signals.py
@@ -106,6 +106,11 @@ class TestWhiteSignals(unittest.TestCase):
         msg = "EFAC covariance incorrect."
         assert np.all(efm.get_ndiag(params) == nvec0), msg
 
+    def test_equad(self):
+        """Test that the deprecated EquadNoise is not available."""
+
+        self.assertRaises(NotImplementedError, white_signals.EquadNoise)
+
     def test_tnequad(self):
         """Test that tnequad signal returns correct covariance."""
         # set up signal and parameters


### PR DESCRIPTION
Instead of defining separate `MeasurementNoise` and `EquadNoise` signals, one would use `CombinedWhiteNoise(efac=..., log10_equad=..., selection=...)`.