### PR TITLE
Fix multivariate-normal parameter bug 

### DIFF
--- a/enterprise/signals/parameter.py
+++ b/enterprise/signals/parameter.py
@@ -228,7 +228,7 @@ def NormalSampler(mu, sigma, size=None):
     vector value/mu and compatible covariance matrix sigma."""
 
     if np.ndim(sigma) == 2:
-        return np.random.multivariate_normal(mu, sigma, size=size)
+        return np.random.multivariate_normal(mu, sigma)
     else:
         return np.random.normal(mu, sigma, size=size)
 

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -98,6 +98,3 @@ class TestParameter(unittest.TestCase):
 
         x1, x2 = NormalSampler(mu, sigma), scipy.stats.multivariate_normal.rvs(mean=mu, cov=sigma)
         assert x1.shape == x2.shape, msg2
-
-        x1, x2 = NormalSampler(mu, sigma, size=10), scipy.stats.multivariate_normal.rvs(mean=mu, cov=sigma, size=10)
-        assert x1.shape == x2.shape, msg2

--- a/tests/test_pulsar.py
+++ b/tests/test_pulsar.py
@@ -203,7 +203,7 @@ class TestPulsarPint(TestPulsar):
 
         with self.assertRaises(pint.models.timing_model.TimingModelError):
             # initialize Pulsar class with RAJ DECJ and PMLAMBDA, PMBETA
-            psr = Pulsar(
+            Pulsar(
                 datadir + "/J0030+0451_RADEC_wrong.par",
                 datadir + "/J0030+0451_NANOGrav_9yv1.tim",
                 ephem="DE430",

--- a/tests/test_pulsar.py
+++ b/tests/test_pulsar.py
@@ -20,6 +20,8 @@ import numpy as np
 
 from enterprise.pulsar import Pulsar
 from tests.enterprise_test_data import datadir
+
+import pint.models.timing_model
 from pint.models import get_model_and_toas
 
 
@@ -196,18 +198,18 @@ class TestPulsarPint(TestPulsar):
     def test_deflate_inflate(self):
         pass
 
-    def test_load_radec_psr(cls):
+    def test_load_radec_psr(self):
         """Setup the Pulsar object."""
 
-        # initialize Pulsar class with RA DEC
-        psr = Pulsar(
-            datadir + "/J0030+0451_RADEC_wrong.par",
-            datadir + "/J0030+0451_NANOGrav_9yv1.tim",
-            ephem="DE430",
-            drop_pintpsr=False,
-            timing_package="pint",
-        )
-        assert "AstrometryEquatorial" in psr.model.components
+        with self.assertRaises(pint.models.timing_model.TimingModelError):
+            # initialize Pulsar class with RAJ DECJ and PMLAMBDA, PMBETA
+            psr = Pulsar(
+                datadir + "/J0030+0451_RADEC_wrong.par",
+                datadir + "/J0030+0451_NANOGrav_9yv1.tim",
+                ephem="DE430",
+                drop_pintpsr=False,
+                timing_package="pint",
+            )
 
     def test_no_planet(self):
         """Test exception when incorrect par(tim) file given."""


### PR DESCRIPTION
Current code fails when specifying `sigma` as a matrix and `size` explicitly, due to a quirk in the `numpy` interface. Thanks to Aurelien Chalumeau for flagging this.