### PR TITLE
TruncNormal

### DIFF
--- a/enterprise/signals/parameter.py
+++ b/enterprise/signals/parameter.py
@@ -307,12 +307,15 @@ def TruncNormal(mu=0, sigma=1, pmin=-2, pmax=2, size=None):
     """
 
     class TruncNormal(Parameter):
-        _norm = (
-            2
-            / np.sqrt(2 * np.pi)
-            / sigma
-            / (_erf((pmax - mu) / sigma / np.sqrt(2)) - _erf((pmin - mu) / sigma / np.sqrt(2)))
-        )
+        try:
+            _norm = (
+                2
+                / np.sqrt(2 * np.pi)
+                / sigma
+                / (_erf((pmax - mu) / sigma / np.sqrt(2)) - _erf((pmin - mu) / sigma / np.sqrt(2)))
+            )
+        except TypeError:
+            _norm = None
         _size = size
         _prior = Function(TruncNormalPrior, mu=mu, sigma=sigma, pmin=pmin, pmax=pmax, norm=_norm)
         _sampler = staticmethod(TruncNormalSampler)

--- a/enterprise/signals/parameter.py
+++ b/enterprise/signals/parameter.py
@@ -6,6 +6,7 @@ import functools
 import inspect
 
 import numpy as np
+from scipy.special import erf as _erf
 
 from enterprise.signals.selections import selection_func
 
@@ -253,6 +254,72 @@ def Normal(mu=0, sigma=1, size=None):
         _typename = _argrepr("Normal", mu=mu, sigma=sigma)
 
     return Normal
+
+
+def TruncNormalPrior(value, mu, sigma, pmin, pmax, norm=None):
+    """Prior function for TruncNormal parameters.
+    Handles scalar mu/sigma/pmin/pmax or compatible vector
+    value/mu/sigma/pmin/pmax/.
+    """
+    if norm is None:
+        norm = (
+			2 / np.sqrt(2 * np.pi) / sigma
+            / (_erf((pmax - mu) / sigma / np.sqrt(2)) 
+			   - _erf((pmin - mu) / sigma / np.sqrt(2)))
+		)
+    arg = -0.5 * ((value - mu) / sigma)**2
+    return norm * np.exp(arg) * ((value > pmin) & (value < pmax))
+
+
+def TruncNormalSampler(mu, sigma, pmin, pmax, norm=None, size=None):
+    """Sampling function for TruncNormal parameters.
+    Handles scalar mu and sigma, compatible vector value/mu/sigma,
+    vector value/mu and compatible covariance matrix sigma.
+    Implements rejection sampling on a normal distribution.
+    """
+    samp = np.random.normal(mu, sigma, size)
+    if isinstance(samp, np.ndarray):
+        mask = np.logical_or(samp > pmax, samp < pmin)
+        while np.any(mask):
+            if isinstance(mu, np.ndarray):
+                samp[mask] = np.random.normal(mu[mask], sigma[mask],
+                                              size=sum(mask))
+            else:
+                samp[mask] = np.random.normal(mu, sigma, size=sum(mask))
+            mask = np.logical_or(samp > pmax, samp < pmin)
+    else:
+        while samp > pmax or samp < pmin:
+            samp = np.random.normal(mu, sigma)
+    return samp
+
+
+def TruncNormal(mu=0, sigma=1, pmin=-2, pmax=2, size=None):
+    """Class factory for TruncNormal parameters
+    (with pdf(x) ~ N(``mu``,``sigma``) on a finite, truncated domain).
+    Handles vectors correctly if ``size == len(mu) == len(sigma)``,
+    in which case ``sigma`` is taken as the sqrt of the diagonal
+    of the covariance matrix.
+    :param mu:    center of normal distribution
+    :param sigma: standard deviation of normal distribution
+    :param pmin:  lower bound of domain
+    :param pmax:  upper bound of domain
+    :param size:  length for vector parameter
+    :return:      `TruncNormal`` parameter class
+    """
+
+    class TruncNormal(Parameter):
+        _norm = (
+			2 / np.sqrt(2 * np.pi) / sigma
+            / (_erf((pmax - mu) / sigma / np.sqrt(2)) 
+			   - _erf((pmin - mu) / sigma / np.sqrt(2)))
+        )
+        _size = size
+        _prior = Function(TruncNormalPrior, mu=mu, sigma=sigma, 
+                          pmin=pmin, pmax=pmax, norm=_norm)
+        _sampler = staticmethod(TruncNormalSampler)
+        _typename = _argrepr("TruncNormal", mu=mu, sigma=sigma, pmin=pmin, pmax=pmax)
+
+    return TruncNormal
 
 
 def LinearExpPrior(value, pmin, pmax):

--- a/enterprise/signals/parameter.py
+++ b/enterprise/signals/parameter.py
@@ -262,11 +262,12 @@ def TruncNormalPrior(value, mu, sigma, pmin, pmax, norm=None):
     """
     if norm is None:
         norm = (
-			2 / np.sqrt(2 * np.pi) / sigma
-            / (_erf((pmax - mu) / sigma / np.sqrt(2)) 
-			   - _erf((pmin - mu) / sigma / np.sqrt(2)))
-		)
-    arg = -0.5 * ((value - mu) / sigma)**2
+            2
+            / np.sqrt(2 * np.pi)
+            / sigma
+            / (_erf((pmax - mu) / sigma / np.sqrt(2)) - _erf((pmin - mu) / sigma / np.sqrt(2)))
+        )
+    arg = -0.5 * ((value - mu) / sigma) ** 2
     return norm * np.exp(arg) * ((value > pmin) & (value < pmax))
 
 
@@ -281,8 +282,7 @@ def TruncNormalSampler(mu, sigma, pmin, pmax, norm=None, size=None):
         mask = np.logical_or(samp > pmax, samp < pmin)
         while np.any(mask):
             if isinstance(mu, np.ndarray):
-                samp[mask] = np.random.normal(mu[mask], sigma[mask],
-                                              size=sum(mask))
+                samp[mask] = np.random.normal(mu[mask], sigma[mask], size=sum(mask))
             else:
                 samp[mask] = np.random.normal(mu, sigma, size=sum(mask))
             mask = np.logical_or(samp > pmax, samp < pmin)
@@ -308,13 +308,13 @@ def TruncNormal(mu=0, sigma=1, pmin=-2, pmax=2, size=None):
 
     class TruncNormal(Parameter):
         _norm = (
-			2 / np.sqrt(2 * np.pi) / sigma
-            / (_erf((pmax - mu) / sigma / np.sqrt(2)) 
-			   - _erf((pmin - mu) / sigma / np.sqrt(2)))
+            2
+            / np.sqrt(2 * np.pi)
+            / sigma
+            / (_erf((pmax - mu) / sigma / np.sqrt(2)) - _erf((pmin - mu) / sigma / np.sqrt(2)))
         )
         _size = size
-        _prior = Function(TruncNormalPrior, mu=mu, sigma=sigma, 
-                          pmin=pmin, pmax=pmax, norm=_norm)
+        _prior = Function(TruncNormalPrior, mu=mu, sigma=sigma, pmin=pmin, pmax=pmax, norm=_norm)
         _sampler = staticmethod(TruncNormalSampler)
         _typename = _argrepr("TruncNormal", mu=mu, sigma=sigma, pmin=pmin, pmax=pmax)
 

--- a/enterprise/signals/parameter.py
+++ b/enterprise/signals/parameter.py
@@ -273,8 +273,8 @@ def TruncNormalPrior(value, mu, sigma, pmin, pmax, norm=None):
 
 def TruncNormalSampler(mu, sigma, pmin, pmax, norm=None, size=None):
     """Sampling function for TruncNormal parameters.
-    Handles scalar mu and sigma, compatible vector value/mu/sigma,
-    vector value/mu and compatible covariance matrix sigma.
+    Handles scalar mu/sigma/pmin/pmax or compatible vector
+    value/mu/sigma/pmin/pmax/.
     Implements rejection sampling on a normal distribution.
     """
     samp = np.random.normal(mu, sigma, size)

--- a/enterprise/signals/parameter.py
+++ b/enterprise/signals/parameter.py
@@ -1,7 +1,6 @@
 # parameter.py
 """Contains parameter types for use in `enterprise` ``Signal`` classes."""
 
-import math
 import functools
 import inspect
 
@@ -218,9 +217,9 @@ def NormalPrior(value, mu, sigma):
 
     if np.ndim(sigma) == 2:
         dx = value - mu
-        return np.exp(-0.5 * np.dot(dx, np.dot(np.linalg.inv(sigma), dx))) / np.sqrt(np.linalg.det(2 * math.pi * sigma))
+        return np.exp(-0.5 * np.dot(dx, np.dot(np.linalg.inv(sigma), dx))) / np.sqrt(np.linalg.det(2 * np.pi * sigma))
     else:
-        return np.exp(-0.5 * (value - mu) ** 2 / sigma**2) / np.sqrt(2 * math.pi * sigma**2)
+        return np.exp(-0.5 * (value - mu) ** 2 / sigma**2) / np.sqrt(2 * np.pi * sigma**2)
 
 
 def NormalSampler(mu, sigma, size=None):

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -188,7 +188,7 @@ class TestParameter(unittest.TestCase):
         paramB = TruncNormal(mu, sigma, -np.inf, np.inf)("B")
         xs = np.linspace(-3, 3, 20)
         assert np.allclose(paramA.get_pdf(xs), paramB.get_pdf(xs)), msg3
-    
+
     def test_metaparam(self):
         mu = Uniform(-1, 1)("mean")
         sigma = 2

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -14,8 +14,8 @@ import numpy as np
 import scipy.stats
 
 from enterprise.signals.parameter import UniformPrior, UniformSampler
-from enterprise.signals.parameter import NormalPrior, NormalSampler
-from enterprise.signals.parameter import TruncNormalPrior, TruncNormalSampler
+from enterprise.signals.parameter import NormalPrior, NormalSampler, Normal
+from enterprise.signals.parameter import TruncNormalPrior, TruncNormalSampler, TruncNormal
 from enterprise.signals.parameter import LinearExpPrior, LinearExpSampler
 
 
@@ -178,3 +178,13 @@ class TestParameter(unittest.TestCase):
 
         x1, x2 = TruncNormalSampler(mu, sigma, pmin, pmax), scipy.stats.truncnorm.rvs(a, b, mu, sigma)
         assert x1.shape == x2.shape, msg2
+
+    def test_normalandtruncnormal(self):
+        mu, sigma = 0, 1
+
+        msg3 = "Normal and [-inf, inf] TruncNormal do not match"
+
+        paramA = Normal(mu, sigma)("A")
+        paramB = TruncNormal(mu, sigma, -np.inf, np.inf)("B")
+        xs = np.linspace(-3, 3, 20)
+        assert np.allclose(paramA.get_pdf(xs), paramB.get_pdf(xs)), msg3

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -13,7 +13,7 @@ import unittest
 import numpy as np
 import scipy.stats
 
-from enterprise.signals.parameter import UniformPrior, UniformSampler
+from enterprise.signals.parameter import UniformPrior, UniformSampler, Uniform
 from enterprise.signals.parameter import NormalPrior, NormalSampler, Normal
 from enterprise.signals.parameter import TruncNormalPrior, TruncNormalSampler, TruncNormal
 from enterprise.signals.parameter import LinearExpPrior, LinearExpSampler
@@ -188,3 +188,15 @@ class TestParameter(unittest.TestCase):
         paramB = TruncNormal(mu, sigma, -np.inf, np.inf)("B")
         xs = np.linspace(-3, 3, 20)
         assert np.allclose(paramA.get_pdf(xs), paramB.get_pdf(xs)), msg3
+    
+    def test_metaparam(self):
+        mu = Uniform(-1, 1)("mean")
+        sigma = 2
+        pmin, pmax = -3, 3
+
+        msg4 = "problem with meta-parameter in TruncNormal"
+        zeros = np.zeros(2)
+
+        paramA = TruncNormal(mu, sigma, pmin, pmax)("A")
+        xs = np.array([-3.5, 3.5])
+        assert np.alltrue(paramA.get_pdf(xs, mu=mu.sample()) == zeros), msg4

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -135,7 +135,7 @@ class TestParameter(unittest.TestCase):
 
         x1, x2 = NormalSampler(mu, sigma), scipy.stats.multivariate_normal.rvs(mean=mu, cov=sigma)
         assert x1.shape == x2.shape, msg2
-    
+
     def test_truncnormal(self):
         """Test TruncNormal parameter prior and sampler for various combinations of scalar and vector arguments."""
 
@@ -146,8 +146,7 @@ class TestParameter(unittest.TestCase):
 
         msg1 = "Enterprise and scipy priors do not match"
         assert np.allclose(
-            TruncNormalPrior(x, mu, sigma, pmin, pmax),
-            scipy.stats.truncnorm.pdf(x, a, b, mu, sigma)
+            TruncNormalPrior(x, mu, sigma, pmin, pmax), scipy.stats.truncnorm.pdf(x, a, b, mu, sigma)
         ), msg1
 
         msg2 = "Enterprise samples have wrong value, type, or size"
@@ -159,13 +158,12 @@ class TestParameter(unittest.TestCase):
         x = np.array([-0.2, 0.1, 0.5])
 
         assert np.allclose(
-            TruncNormalPrior(x, mu, sigma, pmin, pmax),
-            scipy.stats.truncnorm.pdf(x, a, b, mu, sigma)
+            TruncNormalPrior(x, mu, sigma, pmin, pmax), scipy.stats.truncnorm.pdf(x, a, b, mu, sigma)
         ), msg1
 
         x1, x2 = (
             TruncNormalSampler(mu, sigma, pmin, pmax, size=10),
-            scipy.stats.truncnorm.rvs(a, b, mu, sigma, size=10)
+            scipy.stats.truncnorm.rvs(a, b, mu, sigma, size=10),
         )
         assert x1.shape == x2.shape, msg2
 
@@ -175,12 +173,8 @@ class TestParameter(unittest.TestCase):
         pmin, pmax = np.array([-2, -2, -3]), np.array([1, 2, 1])
         a, b = (pmin - mu) / sigma, (pmax - mu) / sigma
         assert np.allclose(
-            TruncNormalPrior(x, mu, sigma, pmin, pmax),
-            scipy.stats.truncnorm.pdf(x, a, b, mu, sigma)
+            TruncNormalPrior(x, mu, sigma, pmin, pmax), scipy.stats.truncnorm.pdf(x, a, b, mu, sigma)
         ), msg1
 
-        x1, x2 = (
-            TruncNormalSampler(mu, sigma, pmin, pmax),
-            scipy.stats.truncnorm.rvs(a, b, mu, sigma)
-        )
+        x1, x2 = TruncNormalSampler(mu, sigma, pmin, pmax), scipy.stats.truncnorm.rvs(a, b, mu, sigma)
         assert x1.shape == x2.shape, msg2


### PR DESCRIPTION
This implements a truncated normal parameter as `enterprise.signals.parameter.TruncNormal`.  The truncated normal distribution matches the usual normal distribution up to normalization within a finite domain, and is zero outside of that domain.

This parameter class can be used to avoid the error described in #321.

`TruncNormal` handles scalar and vector parameters, including vectors where each element has a unique mean, deviation, and domain.  Unlike `Normal`, it cannot handle a full multivariate distribution defined by a covariance matrix.

This example code block shows the prior function and output of the sampler in agreement:
```python
N = 50_000
mu, sig, pmin, pmax = 0.50, 0.30, -1, 1
cosT = parameter.TruncNormal(mu, sig, pmin, pmax)("cosT")
samps = [cosT.sample() for ii in range(N)]

xs = np.linspace(-2, 2, 200)
pdf = cosT.get_pdf(xs)

plt.hist(samps, bins=30, histtype="step", density=True)
plt.plot(xs, pdf)
```
![truncnorm](https://user-images.githubusercontent.com/7785231/188707050-2b208a7f-7554-4952-8373-8e504fd1c392.png)
