### PR TITLE
Modify dmequad semantics in WidebandTimingModel to match MeasurementNoise

### DIFF
--- a/enterprise/pulsar.py
+++ b/enterprise/pulsar.py
@@ -237,6 +237,14 @@ class BasePulsar(object):
 
         return {flag: self._flags[flag][self._isort] for flag in flagnames}
 
+    def set_flags(self, flagname, values):
+        """Set value of existing or new flags."""
+
+        if isinstance(self._flags, np.ndarray):
+            raise NotImplementedError("Cannot set flags when stored as numpy.ndarray.")
+        else:
+            self._flags[flagname] = values[self._iisort]
+
     @property
     def backend_flags(self):
         """Return array of backend flags.

--- a/enterprise/signals/gp_signals.py
+++ b/enterprise/signals/gp_signals.py
@@ -513,14 +513,15 @@ def WidebandTimingModel(
     dmefac=parameter.Uniform(pmin=0.1, pmax=10.0),
     log10_dmequad=parameter.Uniform(pmin=-7.0, pmax=0.0),
     dmjump=parameter.Uniform(pmin=-0.01, pmax=0.01),
-    dmefac_selection=Selection(selections.no_selection),
-    log10_dmequad_selection=Selection(selections.no_selection),
+    selection=Selection(selections.no_selection),
     dmjump_selection=Selection(selections.no_selection),
     dmjump_ref=None,
     name="wideband_timing_model",
 ):
     """Class factory for marginalized linear timing model signals
-    that take wideband TOAs and DMs.  Currently assumes DMX for DM model."""
+    that take wideband TOAs and DMs. DM noise can be adjusted in analogy to
+    the tempo/tempo2/pint parameter convention, variance = dmefac^2 (dmerr^2 + equad^2).
+    Currently assumes DMX for DM model."""
 
     basis = utils.unnormed_tm_basis()  # will need to normalize phi otherwise
     prior = utils.tm_prior()  # standard
@@ -537,15 +538,10 @@ def WidebandTimingModel(
             super(WidebandTimingModel, self).__init__(psr)
             self.name = self.psrname + "_" + self.signal_id
 
-            # make selection for DMEFACs
-            dmefac_select = dmefac_selection(psr)
-            self._dmefac_keys = list(sorted(dmefac_select.masks.keys()))
-            self._dmefac_masks = [dmefac_select.masks[key] for key in self._dmefac_keys]
-
-            # make selection for DMEQUADs
-            log10_dmequad_select = log10_dmequad_selection(psr)
-            self._log10_dmequad_keys = list(sorted(log10_dmequad_select.masks.keys()))
-            self._log10_dmequad_masks = [log10_dmequad_select.masks[key] for key in self._log10_dmequad_keys]
+            # make selection for DMEFAC and DMEQUADs
+            dm_select = selection(psr)
+            self._dm_keys = list(sorted(dm_select.masks.keys()))
+            self._dm_masks = [dm_select.masks[key] for key in self._dm_keys]
 
             # make selection for DMJUMPs
             dmjump_select = dmjump_selection(psr)
@@ -559,32 +555,27 @@ def WidebandTimingModel(
 
             self._params = {}
 
-            self._dmefacs = []
-            for key in self._dmefac_keys:
+            self._dmefacs, self._log10_dmequads = [], []
+            for key in self._dm_keys:
                 pname = "_".join([n for n in [psr.name, key, "dmefac"] if n])
                 param = dmefac(pname)
 
                 self._dmefacs.append(param)
                 self._params[param.name] = param
 
-            self._log10_dmequads = []
-            for key in self._log10_dmequad_keys:
-                pname = "_".join([n for n in [psr.name, key, "log10_dmequad"] if n])
-                param = log10_dmequad(pname)
+                if log10_dmequad is not None:
+                    pname = "_".join([n for n in [psr.name, key, "log10_dmequad"] if n])
+                    param = log10_dmequad(pname)
 
-                self._log10_dmequads.append(param)
-                self._params[param.name] = param
+                    self._log10_dmequads.append(param)
+                    self._params[param.name] = param
 
             self._dmjumps = []
             if dmjump is not None:
                 for key in self._dmjump_keys:
                     pname = "_".join([n for n in [psr.name, key, "dmjump"] if n])
-                    if dmjump_ref is not None:
-                        if pname == psr.name + "_" + dmjump_ref + "_dmjump":
-                            fixed_dmjump = parameter.Constant(val=0.0)
-                            param = fixed_dmjump(pname)
-                        else:
-                            param = dmjump(pname)
+                    if dmjump_ref is not None and key == dmjump_ref:
+                        param = parameter.Constant(val=0.0)(pname)
                     else:
                         param = dmjump(pname)
 
@@ -688,22 +679,20 @@ def WidebandTimingModel(
         def get_dme(self, params):
             """Return EFAC- and EQUAD-weighted DM errors."""
 
-            return (
-                sum(
-                    (params[efac.name] if efac.name in params else efac.value) * mask
-                    for efac, mask in zip(self._dmefacs, self._dmefac_masks)
+            efac_vec = sum(
+                (params[efac.name] if efac.name in params else efac.value) * mask
+                for efac, mask in zip(self._dmefacs, self._dm_masks)
+            )
+
+            if self._log10_dmequads:
+                equad_vec = sum(
+                    10 ** (params[equad.name] if equad.name in params else equad.value) * mask
+                    for equad, mask in zip(self._log10_dmequads, self._dm_masks)
                 )
-                ** 2
-                * self._dmerr**2
-                + (
-                    10
-                    ** sum(
-                        (params[equad.name] if equad.name in params else equad.value) * mask
-                        for equad, mask in zip(self._log10_dmequads, self._log10_dmequad_masks)
-                    )
-                )
-                ** 2
-            ) ** 0.5
+
+                return np.sqrt(efac_vec**2 * (self._dmerr**2 + equad_vec**2))
+            else:
+                return np.sqrt(efac_vec**2 * self._dmerr**2)
 
         @signal_base.cache_call(["delay_params"])
         def get_mean_dm(self, params):

--- a/enterprise/signals/gp_signals.py
+++ b/enterprise/signals/gp_signals.py
@@ -519,9 +519,14 @@ def WidebandTimingModel(
     name="wideband_timing_model",
 ):
     """Class factory for marginalized linear timing model signals
-    that take wideband TOAs and DMs. DM noise can be adjusted in analogy to
-    the tempo/tempo2/pint parameter convention, variance = dmefac^2 (dmerr^2 + equad^2).
-    Currently assumes DMX for DM model."""
+    that take wideband TOAs and DMs. Works in tandem with DMX parameters,
+    by effectively setting their prior mean and variance.
+    DM noise can be adjusted in analogy to the tempo/tempo2/PINT parameter
+    convention, with variance = dmefac^2 (dmerr^2 + dmequad^2).
+    DM noise can be segmented with `selection` (e.g., backends).
+    DM jumps can also be added for each `dmjump_selection`;
+    setting `dmjump_ref` to one of the selection labels keeps the
+    corresponding jump to zero."""
 
     basis = utils.unnormed_tm_basis()  # will need to normalize phi otherwise
     prior = utils.tm_prior()  # standard

--- a/enterprise/signals/selections.py
+++ b/enterprise/signals/selections.py
@@ -52,7 +52,12 @@ def selection_func(func):
 
 
 def Selection(func):
-    """Class factory for TOA selection."""
+    """Class factory for residual selection."""
+
+    # if we wished to pre-wrap standard selections below with the decorator @Selection,
+    # here we would make sure they are not wrapped twice
+    # if hasattr(func, 'masks'):
+    #     return func
 
     class Selection(object):
         def __init__(self, psr):

--- a/tests/test_gp_wideband.py
+++ b/tests/test_gp_wideband.py
@@ -33,10 +33,9 @@ class TestWidebandTimingModel(unittest.TestCase):
 
         dm = gp_signals.WidebandTimingModel(
             dmefac=parameter.Uniform(0.9, 1.1),
-            dmefac_selection=Selection(selections.by_backend),
             log10_dmequad=parameter.Uniform(-7.0, 0.0),
-            log10_dmequad_selection=Selection(selections.by_backend),
             dmjump=parameter.Normal(0, 1),
+            selection=Selection(selections.by_backend),
             dmjump_selection=Selection(selections.by_frontend),
             dmjump_ref=None,
             name="wideband_timing_model",
@@ -52,11 +51,8 @@ class TestWidebandTimingModel(unittest.TestCase):
 
         dmtiming = pta.pulsarmodels[0].signals[1]
 
-        msg = "DMEFAC masks do not cover the data."
-        assert np.all(sum(dmtiming._dmefac_masks) == 1), msg
-
-        msg = "DMEQUAD masks do not cover the data."
-        assert np.all(sum(dmtiming._log10_dmequad_masks) == 1), msg
+        msg = "DM masks do not cover the data."
+        assert np.all(sum(dmtiming._dm_masks) == 1), msg
 
         msg = "DMJUMP masks do not cover the data."
         assert np.all(sum(dmtiming._dmjump_masks) == 1), msg
@@ -127,8 +123,7 @@ class TestWidebandTimingModel(unittest.TestCase):
             dmefac = p1["J1832-0836_" + key + "_dmefac"]
             log10_dmequad = p1["J1832-0836_" + key + "_log10_dmequad"]
             dmequad = 10**log10_dmequad
-            dme_flags_var[mask] *= dmefac
-            dme_flags_var[mask] = (dme_flags_var[mask] ** 2 + dmequad**2) ** 0.5
+            dme_flags_var[mask] = np.sqrt(dmefac**2 * (dme_flags_var[mask] ** 2 + dmequad**2))
 
         for index, par in enumerate(self.psr.fitpars):
             if "DMX" not in par:

--- a/tests/test_pulsar.py
+++ b/tests/test_pulsar.py
@@ -79,13 +79,20 @@ class TestPulsar(unittest.TestCase):
         assert self.psr.freqs.shape == (4005,), msg
 
     def test_flags(self):
-        """Check flags shape and content"""
+        """Check flags shape, content, and setting"""
 
         msg = "Flags shape incorrect"
         assert self.psr.flags["f"].shape == (4005,), msg
 
         msg = "Flag content or sorting incorrect"
         assert np.all(self.psr._flags["fe"][self.psr._isort] == self.psr.flags["fe"]), msg
+
+        # only possible if flags are stored as dict
+        if isinstance(self.psr._flags, dict):
+            self.psr.set_flags("name2", self.psr.flags["name"])
+
+            msg = "Setting flags returns incorrect match"
+            assert np.all(self.psr.flags["name"] == self.psr.flags["name2"])
 
     def test_backend_flags(self):
         """Check backend_flags shape and content"""


### PR DESCRIPTION
- Modified definition of log10_dmequad in WidebandTimingModel (now matches T2EQUAD);
- merged selection masks for dmefac and dmequad;
- allowed setting log10_dmequad=None;
- rationalized code in small ways.