### PR TITLE
Get sksparse and libstempo from PyPI again

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ numpy>=1.16.3
 scipy>=1.2.0
 ephem>=3.7.6.0
 healpy>=1.14.0
-git+https://github.com/vallis/scikit-sparse@master
+scikit-sparse>=0.4.5
 pint-pulsar>=0.8.3
 libstempo>=2.4.4

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,9 @@ requirements = [
     "scipy>=1.2.0",
     "ephem>=3.7.6.0",
     "healpy>=1.14.0",
-    "scikit-sparse @ git+https://github.com/vallis/scikit-sparse@master",  # was >=0.4.5
+    "scikit-sparse>=0.4.5",
     "pint-pulsar>=0.8.3",
-    "libstempo @ git+https://github.com/vallis/libstempo@master",  # was >=2.4.4
+    "libstempo>=2.4.4",
 ]
 
 test_requirements = []


### PR DESCRIPTION
Revert from installing from the GitHub repos to PyPI, since PyPI installs now support Python 3.10.