### PR TITLE
Fixed name collision in class factory definition

### DIFF
--- a/enterprise/signals/deterministic_signals.py
+++ b/enterprise/signals/deterministic_signals.py
@@ -13,13 +13,13 @@ from enterprise.signals.selections import Selection
 def Deterministic(waveform, selection=Selection(selections.no_selection), name=""):
     """Class factory for generic deterministic signals."""
 
-    class Deterministic(signal_base.Signal):
+    class Deterministic_(signal_base.Signal):
         signal_type = "deterministic"
         signal_name = name
         signal_id = name
 
         def __init__(self, psr):
-            super(Deterministic, self).__init__(psr)
+            super(Deterministic_, self).__init__(psr)
             self.name = self.psrname + "_" + self.signal_id
             self._do_selection(psr, waveform, selection)
 
@@ -50,7 +50,7 @@ def Deterministic(waveform, selection=Selection(selections.no_selection), name="
                 delay[mask] = self._wf[key](params=params, mask=mask)
             return delay
 
-    return Deterministic
+    return Deterministic_
 
 
 def PhysicalEphemerisSignal(
@@ -163,12 +163,12 @@ def PhysicalEphemerisSignal(
 
     BaseClass = Deterministic(wf, name=name)
 
-    class PhysicalEphemerisSignal(BaseClass):
+    class PhysicalEphemerisSignal_(BaseClass):
         signal_name = "phys_ephem"
         signal_id = "phys_ephem_" + name if name else "phys_ephem"
 
         def __init__(self, psr):
-            super(PhysicalEphemerisSignal, self).__init__(psr)
+            super(PhysicalEphemerisSignal_, self).__init__(psr)
 
             if use_epoch_toas:
                 # get quantization matrix and calculate daily average TOAs
@@ -206,4 +206,4 @@ def PhysicalEphemerisSignal(
                 delay = self._wf[""](params=params)
                 return delay
 
-    return PhysicalEphemerisSignal
+    return PhysicalEphemerisSignal_

--- a/enterprise/signals/gp_signals.py
+++ b/enterprise/signals/gp_signals.py
@@ -783,13 +783,13 @@ def MarginalizingTimingModel(name="marginalizing_linear_timing_model", use_svd=F
 
     basisFunction = get_timing_model_basis(use_svd, normed)
 
-    class TimingModel_(signal_base.Signal):
+    class MarginalizingTimingModel_(signal_base.Signal):
         signal_type = "white noise"
         signal_name = "marginalizing linear timing model"
         signal_id = name
 
         def __init__(self, psr):
-            super(TimingModel_, self).__init__(psr)
+            super(MarginalizingTimingModel_, self).__init__(psr)
             self.name = self.psrname + "_" + self.signal_id
 
             pname = "_".join([psr.name, name])
@@ -806,7 +806,7 @@ def MarginalizingTimingModel(name="marginalizing_linear_timing_model", use_svd=F
         def get_ndiag(self, params):
             return MarginalizingNmat(self.Mmat()[0])
 
-    return TimingModel_
+    return MarginalizingTimingModel_
 
 
 class MarginalizingNmat(object):

--- a/enterprise/signals/gp_signals.py
+++ b/enterprise/signals/gp_signals.py
@@ -783,13 +783,13 @@ def MarginalizingTimingModel(name="marginalizing_linear_timing_model", use_svd=F
 
     basisFunction = get_timing_model_basis(use_svd, normed)
 
-    class TimingModel(signal_base.Signal):
+    class TimingModel_(signal_base.Signal):
         signal_type = "white noise"
         signal_name = "marginalizing linear timing model"
         signal_id = name
 
         def __init__(self, psr):
-            super(TimingModel, self).__init__(psr)
+            super(TimingModel_, self).__init__(psr)
             self.name = self.psrname + "_" + self.signal_id
 
             pname = "_".join([psr.name, name])
@@ -806,7 +806,7 @@ def MarginalizingTimingModel(name="marginalizing_linear_timing_model", use_svd=F
         def get_ndiag(self, params):
             return MarginalizingNmat(self.Mmat()[0])
 
-    return TimingModel
+    return TimingModel_
 
 
 class MarginalizingNmat(object):

--- a/enterprise/signals/gp_signals.py
+++ b/enterprise/signals/gp_signals.py
@@ -31,7 +31,7 @@ def BasisGP(
 ):
     """Class factory for generic GPs with a basis matrix."""
 
-    class BasisGP(signal_base.Signal):
+    class BasisGP_(signal_base.Signal):
         signal_type = "basis"
         signal_name = name
         signal_id = name
@@ -39,7 +39,7 @@ def BasisGP(
         basis_combine = combine
 
         def __init__(self, psr):
-            super(BasisGP, self).__init__(psr)
+            super(BasisGP_, self).__init__(psr)
             self.name = self.psrname + "_" + self.signal_id
             self._do_selection(psr, priorFunction, basisFunction, coefficients, selection)
 
@@ -182,7 +182,7 @@ def BasisGP(
             def get_phiinv(self, params):
                 return self.get_phi(params).inv()
 
-    return BasisGP
+    return BasisGP_
 
 
 def FourierBasisGP(
@@ -203,12 +203,12 @@ def FourierBasisGP(
     basis = utils.createfourierdesignmatrix_red(nmodes=components, Tspan=Tspan, modes=modes, pshift=pshift, pseed=pseed)
     BaseClass = BasisGP(spectrum, basis, coefficients=coefficients, combine=combine, selection=selection, name=name)
 
-    class FourierBasisGP(BaseClass):
+    class FourierBasisGP_(BaseClass):
         signal_type = "basis"
         signal_name = "red noise"
         signal_id = name
 
-    return FourierBasisGP
+    return FourierBasisGP_
 
 
 def get_timing_model_basis(use_svd=False, normed=True):
@@ -233,7 +233,7 @@ def TimingModel(coefficients=False, name="linear_timing_model", use_svd=False, n
 
     BaseClass = BasisGP(prior, basis, coefficients=coefficients, name=name)
 
-    class TimingModel(BaseClass):
+    class TimingModel_(BaseClass):
         signal_type = "basis"
         signal_name = "linear timing model"
         signal_id = name + "_svd" if use_svd else name
@@ -245,7 +245,7 @@ def TimingModel(coefficients=False, name="linear_timing_model", use_svd=False, n
                 #     than to use 1e40 as in get_phi
                 return 0
 
-    return TimingModel
+    return TimingModel_
 
 
 @function
@@ -269,16 +269,16 @@ def EcorrBasisModel(
     prior = ecorr_basis_prior(log10_ecorr=log10_ecorr)
     BaseClass = BasisGP(prior, basis, coefficients=coefficients, selection=selection, name=name)
 
-    class EcorrBasisModel(BaseClass):
+    class EcorrBasisModel_(BaseClass):
         signal_type = "basis"
         signal_name = "basis ecorr"
         signal_id = name
 
-    return EcorrBasisModel
+    return EcorrBasisModel_
 
 
 def BasisCommonGP(priorFunction, basisFunction, orfFunction, coefficients=False, combine=True, name=""):
-    class BasisCommonGP(signal_base.CommonSignal):
+    class BasisCommonGP_(signal_base.CommonSignal):
         signal_type = "common basis"
         signal_name = "common"
         signal_id = name
@@ -289,7 +289,7 @@ def BasisCommonGP(priorFunction, basisFunction, orfFunction, coefficients=False,
         _prior = priorFunction(name)
 
         def __init__(self, psr):
-            super(BasisCommonGP, self).__init__(psr)
+            super(BasisCommonGP_, self).__init__(psr)
             self.name = self.psrname + "_" + self.signal_id
 
             pname = "_".join([psr.name, name])
@@ -391,19 +391,19 @@ def BasisCommonGP(priorFunction, basisFunction, orfFunction, coefficients=False,
             def get_phi(self, params):
                 self._construct_basis(params)
 
-                prior = BasisCommonGP._prior(self._labels, params=params)
-                orf = BasisCommonGP._orf(self._psrpos, self._psrpos, params=params)
+                prior = BasisCommonGP_._prior(self._labels, params=params)
+                orf = BasisCommonGP_._orf(self._psrpos, self._psrpos, params=params)
 
                 return prior * orf
 
             @classmethod
             def get_phicross(cls, signal1, signal2, params):
-                prior = BasisCommonGP._prior(signal1._labels, params=params)
-                orf = BasisCommonGP._orf(signal1._psrpos, signal2._psrpos, params=params)
+                prior = BasisCommonGP_._prior(signal1._labels, params=params)
+                orf = BasisCommonGP_._orf(signal1._psrpos, signal2._psrpos, params=params)
 
                 return prior * orf
 
-    return BasisCommonGP
+    return BasisCommonGP_
 
 
 def FourierBasisCommonGP(
@@ -427,7 +427,7 @@ def FourierBasisCommonGP(
     basis = utils.createfourierdesignmatrix_red(nmodes=components, Tspan=Tspan, modes=modes, pshift=pshift, pseed=pseed)
     BaseClass = BasisCommonGP(spectrum, basis, orf, coefficients=coefficients, combine=combine, name=name)
 
-    class FourierBasisCommonGP(BaseClass):
+    class FourierBasisCommonGP_(BaseClass):
         signal_type = "common basis"
         signal_name = "common red noise"
         signal_id = name
@@ -435,21 +435,21 @@ def FourierBasisCommonGP(
         _Tmin, _Tmax = [], []
 
         def __init__(self, psr):
-            super(FourierBasisCommonGP, self).__init__(psr)
+            super(FourierBasisCommonGP_, self).__init__(psr)
 
             if Tspan is None:
-                FourierBasisCommonGP._Tmin.append(psr.toas.min())
-                FourierBasisCommonGP._Tmax.append(psr.toas.max())
+                FourierBasisCommonGP_._Tmin.append(psr.toas.min())
+                FourierBasisCommonGP_._Tmax.append(psr.toas.max())
 
         # since this function has side-effects, it can only be cached
         # with limit=1, so it will run again if called with params different
         # than the last time
         @signal_base.cache_call("basis_params", 1)
         def _construct_basis(self, params={}):
-            span = Tspan if Tspan is not None else max(FourierBasisCommonGP._Tmax) - min(FourierBasisCommonGP._Tmin)
+            span = Tspan if Tspan is not None else max(FourierBasisCommonGP_._Tmax) - min(FourierBasisCommonGP_._Tmin)
             self._basis, self._labels = self._bases(params=params, Tspan=span)
 
-    return FourierBasisCommonGP
+    return FourierBasisCommonGP_
 
 
 # for simplicity, we currently do not handle Tspan automatically
@@ -532,7 +532,7 @@ def WidebandTimingModel(
     prior = utils.tm_prior()  # standard
     BaseClass = BasisGP(prior, basis, coefficients=False, name=name)
 
-    class WidebandTimingModel(BaseClass):
+    class WidebandTimingModel_(BaseClass):
         signal_type = "basis"
         signal_name = "wideband timing model"
         signal_id = name
@@ -540,7 +540,7 @@ def WidebandTimingModel(
         basis_combine = False  # should never need to be True
 
         def __init__(self, psr):
-            super(WidebandTimingModel, self).__init__(psr)
+            super(WidebandTimingModel_, self).__init__(psr)
             self.name = self.psrname + "_" + self.signal_id
 
             # make selection for DMEFAC and DMEQUADs
@@ -775,7 +775,7 @@ def WidebandTimingModel(
 
             return chi2
 
-    return WidebandTimingModel
+    return WidebandTimingModel_
 
 
 def MarginalizingTimingModel(name="marginalizing_linear_timing_model", use_svd=False, normed=True):

--- a/enterprise/signals/parameter.py
+++ b/enterprise/signals/parameter.py
@@ -127,13 +127,13 @@ def GPCoefficients(logprior, size):
     """Class factory for GP coefficients, which are usually created
     inside gp_signals.BasisGP."""
 
-    class GPCoefficients(Parameter):
+    class GPCoefficients_(Parameter):
         _size = size
         _logprior = logprior
         _sampler = None  # MV: TO DO, connect with GP object
         _typename = "GPCoefficients"
 
-    return GPCoefficients
+    return GPCoefficients_
 
 
 def UserParameter(prior=None, logprior=None, sampler=None, size=None):
@@ -151,7 +151,7 @@ def UserParameter(prior=None, logprior=None, sampler=None, size=None):
     :return:        ``UserParameter`` class
     """
 
-    class UserParameter(Parameter):
+    class UserParameter_(Parameter):
         _size = size
         if prior is not None:
             _prior = prior
@@ -160,7 +160,7 @@ def UserParameter(prior=None, logprior=None, sampler=None, size=None):
         _sampler = None if sampler is None else staticmethod(sampler)
         _typename = "UserParameter"
 
-    return UserParameter
+    return UserParameter_
 
 
 def _argrepr(typename, **kwargs):
@@ -201,13 +201,13 @@ def Uniform(pmin, pmax, size=None):
     :return:     ``Uniform`` parameter class
     """
 
-    class Uniform(Parameter):
+    class Uniform_(Parameter):
         _size = size
         _prior = Function(UniformPrior, pmin=pmin, pmax=pmax)
         _sampler = staticmethod(UniformSampler)
         _typename = _argrepr("Uniform", pmin=pmin, pmax=pmax)
 
-    return Uniform
+    return Uniform_
 
 
 def NormalPrior(value, mu, sigma):
@@ -246,13 +246,13 @@ def Normal(mu=0, sigma=1, size=None):
     :return:      ``Normal`` parameter class
     """
 
-    class Normal(Parameter):
+    class Normal_(Parameter):
         _size = size
         _prior = Function(NormalPrior, mu=mu, sigma=sigma)
         _sampler = staticmethod(NormalSampler)
         _typename = _argrepr("Normal", mu=mu, sigma=sigma)
 
-    return Normal
+    return Normal_
 
 
 def TruncNormalPrior(value, mu, sigma, pmin, pmax, norm=None):
@@ -306,7 +306,7 @@ def TruncNormal(mu=0, sigma=1, pmin=-2, pmax=2, size=None):
     :return:      `TruncNormal`` parameter class
     """
 
-    class TruncNormal(Parameter):
+    class TruncNormal_(Parameter):
         try:
             _norm = (
                 2
@@ -321,7 +321,7 @@ def TruncNormal(mu=0, sigma=1, pmin=-2, pmax=2, size=None):
         _sampler = staticmethod(TruncNormalSampler)
         _typename = _argrepr("TruncNormal", mu=mu, sigma=sigma, pmin=pmin, pmax=pmax)
 
-    return TruncNormal
+    return TruncNormal_
 
 
 def LinearExpPrior(value, pmin, pmax):
@@ -358,13 +358,13 @@ def LinearExp(pmin, pmax, size=None):
     :return:     ``LinearExp`` parameter class
     """
 
-    class LinearExp(Parameter):
+    class LinearExp_(Parameter):
         _size = size
         _prior = Function(LinearExpPrior, pmin=pmin, pmax=pmax)
         _sampler = staticmethod(LinearExpSampler)
         _typename = _argrepr("LinearExp", pmin=pmin, pmax=pmax)
 
-    return LinearExp
+    return LinearExp_
 
 
 class ConstantParameter(object):
@@ -393,11 +393,11 @@ def Constant(val=None):
     value later, for example with ``signal_base.PTA.set_default_params()``.
     """
 
-    class Constant(ConstantParameter):
+    class Constant_(ConstantParameter):
         # MV: I don't know if this does what it's supposed to...
         value = val
 
-    return Constant
+    return Constant_
 
 
 class FunctionBase(object):
@@ -407,7 +407,7 @@ class FunctionBase(object):
 def Function(func, name="", **func_kwargs):
     fname = name
 
-    class Function(FunctionBase):
+    class Function_(FunctionBase):
         def __init__(self, name, psr=None):
             self._func = selection_func(func)
             self._psr = psr
@@ -534,7 +534,7 @@ def Function(func, name="", **func_kwargs):
         def __repr__(self):
             return "{}({})".format(self.name, ", ".join([str(p) for p in self.params]))
 
-    return Function
+    return Function_
 
 
 def get_funcargs(func):

--- a/enterprise/signals/selections.py
+++ b/enterprise/signals/selections.py
@@ -59,7 +59,7 @@ def Selection(func):
     # if hasattr(func, 'masks'):
     #     return func
 
-    class Selection(object):
+    class Selection_(object):
         def __init__(self, psr):
             self._psr = psr
 
@@ -85,7 +85,7 @@ def Selection(func):
                 ret = params, kmasks
             return ret
 
-    return Selection
+    return Selection_
 
 
 # SELECTION FUNCTIONS

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -758,7 +758,7 @@ def SignalCollection(metasignals):  # noqa: C901
     """Class factory for ``SignalCollection`` objects."""
 
     @six.add_metaclass(MetaCollection)
-    class SignalCollection(object):
+    class SignalCollection_(object):
         _metasignals = metasignals
 
         def __init__(self, psr):
@@ -984,7 +984,7 @@ def SignalCollection(metasignals):  # noqa: C901
         def get_logsignalprior(self, params):
             return sum(signal.get_logsignalprior(params) for signal in self._signals)
 
-    return SignalCollection
+    return SignalCollection_
 
 
 def cache_call(attrs, limit=2):

--- a/enterprise/signals/white_signals.py
+++ b/enterprise/signals/white_signals.py
@@ -15,13 +15,13 @@ from enterprise.signals.selections import Selection
 def WhiteNoise(varianceFunction, selection=Selection(selections.no_selection), name=""):
     """Class factory for generic white noise signals."""
 
-    class WhiteNoise(signal_base.Signal):
+    class WhiteNoise_(signal_base.Signal):
         signal_type = "white noise"
         signal_name = name
         signal_id = name
 
         def __init__(self, psr):
-            super(WhiteNoise, self).__init__(psr)
+            super(WhiteNoise_, self).__init__(psr)
             self.name = self.psrname + "_" + self.signal_id
             self._do_selection(psr, varianceFunction, selection)
 
@@ -49,7 +49,7 @@ def WhiteNoise(varianceFunction, selection=Selection(selections.no_selection), n
                 ret += self._ndiag[key](params=params) * mask
             return signal_base.ndarray_alt(ret)
 
-    return WhiteNoise
+    return WhiteNoise_
 
 
 @function
@@ -78,11 +78,11 @@ def MeasurementNoise(
     )
     BaseClass = WhiteNoise(varianceFunction, selection=selection, name=name)
 
-    class MeasurementNoise(BaseClass):
+    class MeasurementNoise_(BaseClass):
         signal_name = "measurement_noise"
         signal_id = "measurement_noise_" + name if name else "measurement_noise"
 
-    return MeasurementNoise
+    return MeasurementNoise_
 
 
 @function
@@ -96,11 +96,11 @@ def TNEquadNoise(log10_tnequad=parameter.Uniform(-10, -5), selection=Selection(s
     varianceFunction = tnequad_ndiag(log10_tnequad=log10_tnequad)
     BaseClass = WhiteNoise(varianceFunction, selection=selection, name=name)
 
-    class TNEquadNoise(BaseClass):
+    class TNEquadNoise_(BaseClass):
         signal_name = "tnequad"
         signal_id = "tnequad_" + name if name else "tnequad"
 
-    return TNEquadNoise
+    return TNEquadNoise_
 
 
 def EquadNoise(*args, **kwargs):
@@ -170,13 +170,13 @@ def EcorrKernelNoise(
         msg = "EcorrKernelNoise does not support method: {}".format(method)
         raise TypeError(msg)
 
-    class EcorrKernelNoise(signal_base.Signal):
+    class EcorrKernelNoise_(signal_base.Signal):
         signal_type = "white noise"
         signal_name = "ecorr_" + method
         signal_id = "_".join(["ecorr", name, method]) if name else "_".join(["ecorr", method])
 
         def __init__(self, psr):
-            super(EcorrKernelNoise, self).__init__(psr)
+            super(EcorrKernelNoise_, self).__init__(psr)
             self.name = self.psrname + "_" + self.signal_id
 
             sel = selection(psr)
@@ -256,4 +256,4 @@ def EcorrKernelNoise(
             )
             return (slices, jvec)
 
-    return EcorrKernelNoise
+    return EcorrKernelNoise_


### PR DESCRIPTION
This PR fixes #344. Inside the class factories, the class names now have a trailing underscore. This is not a user-facing change.

The main problem is that if you try to access attributes of the function (the class factory) itself, you get an `UnboundLocalError`, because the class that has the same name is in this scope and has not been defined yet. Making the names differ fixes that. A reason to access attributes of the class factory would be to get static variables, so one could for instance issue a warning only once, rather than every time you call a class factory. This can be done with global variables also, but it's less neat.

Currently, this PR is not exhaustive.