### PR TITLE
Pin urllib3 to version<2 for Sphinx/RTD

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,6 +6,7 @@ bumpversion>=0.5.3
 wheel>=0.29.0
 watchdog>=0.9.0
 coverage>=4.5.3
+urllib3<2
 Sphinx>=2.0.0
 cryptography>=2.0.0
 PyYAML>=4.2b1


### PR DESCRIPTION
In order to fix #346, this PR pins urllib3 to version<2.