### PR TITLE
Fixed the TypeError in test_vector_parameter_like

### DIFF
--- a/tests/test_vector_parameter.py
+++ b/tests/test_vector_parameter.py
@@ -75,7 +75,7 @@ class TestVectorParameter(unittest.TestCase):
         pta = signal_base.PTA([s(self.psr)])
 
         # parameters
-        xs = np.hstack(p.sample() for p in pta.params)
+        xs = np.hstack([p.sample() for p in pta.params])
         params = {"B1855+09_red_noise_log10_rho": xs[1:], "B1855+09_efac": xs[0]}
 
         # test log likelihood


### PR DESCRIPTION
The integration tests fail for python 3.9 and 3.10, because the generator object is not converted to a list or tuple in the test function `test_vector_parameter_like`. See issue #354.

This PR fixes #354 by converting the generator object to a list first.