### PR TITLE
Faster sparse matrix Cholesky

### DIFF
--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -223,7 +223,7 @@ class LogLikelihood(object):
                 try:
                     Sigma_sp = TNT + sps.csc_matrix(phiinv)
 
-                    if hasattr(self, 'cf_sp'):
+                    if hasattr(self, "cf_sp"):
                         # Have analytical decomposition already. Just do update
                         self.cf_sp.cholesky_inplace(Sigma_sp)
                     else:

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -221,9 +221,17 @@ class LogLikelihood(object):
 
             if self.cholesky_sparse:
                 try:
-                    cf = cholesky(TNT + sps.csc_matrix(phiinv))  # cf(Sigma)
-                    expval = cf(TNr)
-                    logdet_sigma = cf.logdet()
+                    Sigma_sp = TNT + sps.csc_matrix(phiinv)
+
+                    if hasattr(self, 'cf_sp'):
+                        # Have analytical decomposition already. Just do update
+                        self.cf_sp.cholesky_inplace(Sigma_sp)
+                    else:
+                        # Do analytical and numerical Sparse Cholesky
+                        self.cf_sp = cholesky(Sigma_sp)
+
+                    expval = self.cf_sp(TNr)
+                    logdet_sigma = self.cf_sp.logdet()
                 except CholmodError:  # pragma: no cover
                     return -np.inf
             else:

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -326,6 +326,43 @@ class TestLikelihood(unittest.TestCase):
         msg = "Likelihood mismatch between ECORR methods"
         assert np.allclose(l1, l2), msg
 
+    def test_like_sparse_cache(self):
+        """Test likelihood with sparse Cholesky caching"""
+
+        # find the maximum time span to set GW frequency sampling
+        tmin = [p.toas.min() for p in self.psrs]
+        tmax = [p.toas.max() for p in self.psrs]
+        Tspan = np.max(tmax) - np.min(tmin)
+
+        # setup basic model
+        efac = parameter.Constant(1.0)
+        log10_A = parameter.Constant(-15.0)
+        gamma = parameter.Constant(4.33)
+
+        ef = white_signals.MeasurementNoise(efac)
+        pl = utils.powerlaw(log10_A=log10_A, gamma=gamma)
+
+        orf = utils.hd_orf()
+        crn = gp_signals.FourierBasisCommonGP(pl, orf, components=20, name="GW", Tspan=Tspan)
+
+        tm = gp_signals.TimingModel()
+        m = ef + crn
+
+        # Two identical arrays that we'll compare with two sets of parameters
+        pta1 = signal_base.PTA([m(p) for p in self.psrs])
+        pta2 = signal_base.PTA([m(p) for p in self.psrs])
+
+        params_init = parameter.sample(pta1.params)
+        params_check = parameter.sample(pta1.params)
+
+        # First call for pta1 only initializes the sparse decomposition. Second one uses it
+        _ = pta1.get_lnlikelihood(params_init)
+        l1 = pta1.get_lnlikelihood(params_check)
+        l2 = pta2.get_lnlikelihood(params_check)
+
+        msg = "Likelihood mismatch between sparse Cholesky full & inplace"
+        assert np.allclose(l1, l2), msg
+
 
 class TestLikelihoodPint(TestLikelihood):
     @classmethod

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -346,7 +346,7 @@ class TestLikelihood(unittest.TestCase):
         crn = gp_signals.FourierBasisCommonGP(pl, orf, components=20, name="GW", Tspan=Tspan)
 
         tm = gp_signals.TimingModel()
-        m = ef + crn
+        m = tm + ef + crn
 
         # Two identical arrays that we'll compare with two sets of parameters
         pta1 = signal_base.PTA([m(p) for p in self.psrs])


### PR DESCRIPTION
This PR changes the way the sparse matrix Cholesky is carried out. The first time the likelihood is called, a regular

```python
self.cf = cholesky(Sigma_sp)
```

is done. However, every subsequent call only the numerical decomposition is carried out. The analytical sparse decomposition takes a significant amount of time for our decompositions, so there is a speedup by just doing an 'update':

```python
self.cf.cholesky_inplace(Sigma_sp)
```

For the NANOGrav 15yr set, this alone reduces the model_3A time on my laptop from 370ms to 280ms. Additional speedups might be possible in the construction and decomposition of 'phi'