### PR TITLE
fix missing cholmod.h

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -37,6 +37,10 @@ jobs:
       run: |
         sudo apt-get install libsuitesparse-dev
         curl -sSL https://raw.githubusercontent.com/vallis/libstempo/master/install_tempo2.sh | sh
+    - name: Set path for Mac scikit-sparse installation
+      if: runner.os == 'macOS'
+      run: |
+        export SUITESPARSE_INCLUDE_DIR="/usr/include/suitesparse/include/suitesparse"
     - name: Install dependencies and package
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -31,7 +31,6 @@ jobs:
       run: |
         brew unlink gcc && brew link gcc
         brew install automake suite-sparse
-        ls /usr/local/opt/suite-sparse/include/
         curl -sSL https://raw.githubusercontent.com/vallis/libstempo/master/install_tempo2.sh | sh
     - name: Install non-python dependencies on linux
       if: runner.os == 'Linux'
@@ -40,7 +39,8 @@ jobs:
         curl -sSL https://raw.githubusercontent.com/vallis/libstempo/master/install_tempo2.sh | sh
     - name: Install dependencies and package
       env:
-        SUITESPARSE_INCLUDE_DIR: "/usr/local/opt/suite-sparse/include/"
+        SUITESPARSE_INCLUDE_DIR: "/usr/local/opt/suite-sparse/include/suitesparse/include"
+        SUITESPARSE_LIBRARY_DIR: "/usr/local/opt/suite-sparse/lib"
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install -r requirements_dev.txt

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -31,6 +31,7 @@ jobs:
       run: |
         brew unlink gcc && brew link gcc
         brew install automake suite-sparse
+        ls /usr/local/opt/suite-sparse/include/suitesparse/
         curl -sSL https://raw.githubusercontent.com/vallis/libstempo/master/install_tempo2.sh | sh
     - name: Install non-python dependencies on linux
       if: runner.os == 'Linux'

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -42,6 +42,7 @@ jobs:
       run: |
         export SUITESPARSE_INCLUDE_DIR="/usr/local/opt/suitesparse/include/suitesparse"
         echo $SUITESPARSE_INCLUDE_DIR
+        brew --prefix suite-sparse
     - name: Install dependencies and package
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest] # [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
@@ -31,7 +31,6 @@ jobs:
       run: |
         brew unlink gcc && brew link gcc
         brew install automake suite-sparse
-        ls /usr/local/opt/suite-sparse/include/suitesparse/
         curl -sSL https://raw.githubusercontent.com/vallis/libstempo/master/install_tempo2.sh | sh
     - name: Install non-python dependencies on linux
       if: runner.os == 'Linux'

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         brew unlink gcc && brew link gcc
         brew install automake suite-sparse
-        brew --prefix suite-sparse
+        ls /usr/local/opt/suite-sparse/
         curl -sSL https://raw.githubusercontent.com/vallis/libstempo/master/install_tempo2.sh | sh
     - name: Install non-python dependencies on linux
       if: runner.os == 'Linux'
@@ -40,7 +40,7 @@ jobs:
         curl -sSL https://raw.githubusercontent.com/vallis/libstempo/master/install_tempo2.sh | sh
     - name: Install dependencies and package
       env:
-        SUITESPARSE_INCLUDE_DIR: "/usr/local/bin/suitesparse/include/suitesparse"
+        SUITESPARSE_INCLUDE_DIR: "/usr/local/opt/suite-sparse/include/"
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install -r requirements_dev.txt

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -31,19 +31,16 @@ jobs:
       run: |
         brew unlink gcc && brew link gcc
         brew install automake suite-sparse
+        brew --prefix suite-sparse
         curl -sSL https://raw.githubusercontent.com/vallis/libstempo/master/install_tempo2.sh | sh
     - name: Install non-python dependencies on linux
       if: runner.os == 'Linux'
       run: |
         sudo apt-get install libsuitesparse-dev
         curl -sSL https://raw.githubusercontent.com/vallis/libstempo/master/install_tempo2.sh | sh
-    - name: Set path for Mac scikit-sparse installation
-      if: runner.os == 'macOS'
-      run: |
-        export SUITESPARSE_INCLUDE_DIR="/usr/local/opt/suitesparse/include/suitesparse"
-        echo $SUITESPARSE_INCLUDE_DIR
-        brew --prefix suite-sparse
     - name: Install dependencies and package
+      env:
+        SUITESPARSE_INCLUDE_DIR: "/usr/local/bin/suitesparse/include/suitesparse"
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install -r requirements_dev.txt

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -40,7 +40,8 @@ jobs:
     - name: Set path for Mac scikit-sparse installation
       if: runner.os == 'macOS'
       run: |
-        export SUITESPARSE_INCLUDE_DIR="/usr/include/suitesparse/include/suitesparse"
+        export SUITESPARSE_INCLUDE_DIR="/usr/local/opt/suitesparse/include/suitesparse"
+        echo $SUITESPARSE_INCLUDE_DIR
     - name: Install dependencies and package
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [macos-latest] # [ubuntu-latest, macos-latest]
         python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
@@ -31,7 +31,7 @@ jobs:
       run: |
         brew unlink gcc && brew link gcc
         brew install automake suite-sparse
-        ls /usr/local/opt/suite-sparse/
+        ls /usr/local/opt/suite-sparse/include/
         curl -sSL https://raw.githubusercontent.com/vallis/libstempo/master/install_tempo2.sh | sh
     - name: Install non-python dependencies on linux
       if: runner.os == 'Linux'

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -40,7 +40,7 @@ jobs:
         curl -sSL https://raw.githubusercontent.com/vallis/libstempo/master/install_tempo2.sh | sh
     - name: Install dependencies and package
       env:
-        SUITESPARSE_INCLUDE_DIR: "/usr/local/opt/suite-sparse/include/suitesparse/include"
+        SUITESPARSE_INCLUDE_DIR: "/usr/local/opt/suite-sparse/include/suitesparse/"
         SUITESPARSE_LIBRARY_DIR: "/usr/local/opt/suite-sparse/lib"
       run: |
         python -m pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
At the moment, `suitesparse` has a very odd default installation location after the previous changes to the install.

I think this actually should break on both linux AND mac, but `apt` and `conda` have `suitesparse` version 5.10.1 instead of 7.6.0 which can be found in `brew`.

Running CI to see if things are working now with the updated version