### PR TITLE
Allow efac/log10_tneqad to be None in ndiag functions

### DIFF
--- a/enterprise/signals/white_signals.py
+++ b/enterprise/signals/white_signals.py
@@ -54,12 +54,18 @@ def WhiteNoise(varianceFunction, selection=Selection(selections.no_selection), n
 
 @function
 def efac_ndiag(toaerrs, efac=1.0):
-    return efac**2 * toaerrs**2
+    if efac is None:
+        return toaerrs**2
+    else:
+        return efac**2 * toaerrs**2
 
 
 @function
 def combined_ndiag(toaerrs, efac=1.0, log10_t2equad=-8):
-    return efac**2 * (toaerrs**2 + 10 ** (2 * log10_t2equad))
+    if efac is None and log10_t2equad is None:
+        return toaerrs**2
+    else:
+        return efac**2 * (toaerrs**2 + 10 ** (2 * log10_t2equad))
 
 
 def MeasurementNoise(
@@ -87,7 +93,11 @@ def MeasurementNoise(
 
 @function
 def tnequad_ndiag(toas, log10_tnequad=-8):
-    return np.ones_like(toas) * 10 ** (2 * log10_tnequad)
+    if log10_tnequad is None:
+        return np.zeros_like(toas)
+    else:
+        return np.ones_like(toas) * 10 ** (2 * log10_tnequad)
+    
 
 
 def TNEquadNoise(log10_tnequad=parameter.Uniform(-10, -5), selection=Selection(selections.no_selection), name=""):


### PR DESCRIPTION
In [white_signals.py](https://github.com/nanograv/enterprise/blob/master/enterprise/signals/white_signals.py), the `*_ndiag` functions fail if they get passed `None` values. This happens, for example, if the `white_noise_block` in
[enterprise_extensions](https://github.com/nanograv/enterprise_extensions/blob/master/enterprise_extensions/blocks.py) has `vary=False`, and therefore efac/equad/ecorr are set to `Constant` parameters, which have default values of None.

The two potential fixes are the one in this PR, i.e., allow `None` values, which for `efac_ndiag` is equivalent to having `efac=1.0`, and set `tneqad_ndiag` to zeros if passed `None. The other fix would be to specify values for the `Constants` in the `white_noise_block` in
[enterprise_extensions](https://github.com/nanograv/enterprise_extensions/blob/master/enterprise_extensions/blocks.py), e.g.,:

```python
        efac = parameter.Constant(1.0)
        equad = parameter.Constant(-np.inf)
        if inc_ecorr:
            ecorr = parameter.Constant(-np.inf)
```