### PR TITLE
Update selections.py for "CHIME" and "VEGAS"

### DIFF
--- a/enterprise/signals/selections.py
+++ b/enterprise/signals/selections.py
@@ -118,7 +118,7 @@ def by_backend(backend_flags):
 def nanograv_backends(backend_flags):
     """Selection function to split by NANOGRav backend flags only."""
     flagvals = np.unique(backend_flags)
-    ngb = ["ASP", "GASP", "GUPPI", "PUPPI", "YUPPI"]
+    ngb = ["ASP", "GASP", "GUPPI", "PUPPI", "YUPPI", "CHIME"]
     flagvals = [val for val in flagvals if any([b in val for b in ngb])]
     return {val: backend_flags == val for val in flagvals}
 

--- a/enterprise/signals/selections.py
+++ b/enterprise/signals/selections.py
@@ -118,7 +118,7 @@ def by_backend(backend_flags):
 def nanograv_backends(backend_flags):
     """Selection function to split by NANOGRav backend flags only."""
     flagvals = np.unique(backend_flags)
-    ngb = ["ASP", "GASP", "GUPPI", "PUPPI", "YUPPI", "CHIME"]
+    ngb = ["ASP", "GASP", "GUPPI", "PUPPI", "YUPPI", "CHIME", "VEGAS"]
     flagvals = [val for val in flagvals if any([b in val for b in ngb])]
     return {val: backend_flags == val for val in flagvals}
 


### PR DESCRIPTION
This pull request makes a small change to add "CHIME" and "VEGAS" as backends to 
`def nanograv_backends(backend_flags):`

This will allow for the setup of ECORR for the CHIME and VEGAS backends when running enterprise.