### PR TITLE
feat: partial caching of chromatic Fourier design matrix

### DIFF
--- a/enterprise/signals/gp_bases.py
+++ b/enterprise/signals/gp_bases.py
@@ -334,7 +334,7 @@ def construct_chromatic_cached_parts(
 
 @function
 def createfourierdesignmatrix_chromatic_with_additional_caching(fmat_red=None, Ffreqs=None,
-                                                                fref_over_radio_freqs=None, alpha=4.0):
+                                                                fref_over_radio_freqs=None, idx=4.0):
     """
     Construct Scattering-variation fourier design matrix with a cached achromatic component of the
     Fourier design matrix (fmat_red). (Note this is independent of the actual achroamtic basis.)
@@ -345,12 +345,12 @@ def createfourierdesignmatrix_chromatic_with_additional_caching(fmat_red=None, F
     :param fmat_red: (constant) achromatic Fourier design matrix
     :param Ffreqs: Fourier frequencies
     :param fref_over_radio_freqs: Reference radio frequency (in MHz) over toa radio frequencies (in MHz)
-    :param alpha: Index of chromatic effects. Pass either a float, Constant, or Parameter
+    :param idx: Index of chromatic effects (alpha). Pass either a float, Constant, or Parameter
     :return: Fmat_chromatic: Chromatic-variation Fourier design matrix
     :return: Ffreqs: Fourier modes of the chromatic basis
     """
     # give radio frequencies over reference frequency -alpha chromatic index
-    CM = fref_over_radio_freqs**alpha
+    CM = fref_over_radio_freqs**idx
     return fmat_red * CM[:, None], Ffreqs
 
 

--- a/enterprise/signals/gp_bases.py
+++ b/enterprise/signals/gp_bases.py
@@ -294,7 +294,15 @@ def createfourierdesignmatrix_chromatic(
 
 @function
 def construct_chromatic_cached_parts(
-    toas, freqs, nmodes=30, Tspan=None, logf=False, fmin=None, fmax=None, modes=None, fref=1400,
+    toas,
+    freqs,
+    nmodes=30,
+    Tspan=None,
+    logf=False,
+    fmin=None,
+    fmax=None,
+    modes=None,
+    fref=1400,
 ):
     """
     Using this function alongside `createfourierdesignmatrix_chromatic_with_additional_caching()`
@@ -327,14 +335,15 @@ def construct_chromatic_cached_parts(
         toas, nmodes=nmodes, Tspan=Tspan, logf=logf, fmin=fmin, fmax=fmax, modes=modes
     )
     # compute the reference frequency/toa observational frequency vector
-    fref_over_radio_freqs = (fref / freqs)
+    fref_over_radio_freqs = fref / freqs
 
     return fmat_red, Ffreqs, fref_over_radio_freqs
 
 
 @function
-def createfourierdesignmatrix_chromatic_with_additional_caching(fmat_red=None, Ffreqs=None,
-                                                                fref_over_radio_freqs=None, idx=4.0):
+def createfourierdesignmatrix_chromatic_with_additional_caching(
+    fmat_red=None, Ffreqs=None, fref_over_radio_freqs=None, idx=4.0
+):
     """
     Construct Scattering-variation fourier design matrix with a cached achromatic component of the
     Fourier design matrix (fmat_red). (Note this is independent of the actual achroamtic basis.)

--- a/enterprise/signals/gp_bases.py
+++ b/enterprise/signals/gp_bases.py
@@ -291,7 +291,7 @@ def createfourierdesignmatrix_chromatic(
 
     return F * Dm[:, None], Ffreqs
 
-
+@function
 def construct_chromatic_cached_parts(
     toas, freqs, nmodes=30, Tspan=None, logf=False, fmin=None, fmax=None, modes=None, fref=1400,
 ):

--- a/enterprise/signals/gp_bases.py
+++ b/enterprise/signals/gp_bases.py
@@ -291,6 +291,7 @@ def createfourierdesignmatrix_chromatic(
 
     return F * Dm[:, None], Ffreqs
 
+
 @function
 def construct_chromatic_cached_parts(
     toas, freqs, nmodes=30, Tspan=None, logf=False, fmin=None, fmax=None, modes=None, fref=1400,
@@ -299,10 +300,10 @@ def construct_chromatic_cached_parts(
     Using this function alongside `createfourierdesignmatrix_chromatic_with_additional_caching()`
     enables caching of the achromatic portion of the chromatic Fourier designmatrix as well as caching
     the division of the reference radio frequency (fref) and observational radio frequency vector (freqs).
-    The actual caching occurs via the @function decorator on the 
+    The actual caching occurs via the @function decorator on the
     `createfourierdesignmatrix_chromatic_with_additional_caching()`, where the decorator is defined in
     `enterprise.signals.parameter.function`.
-    Note that the "achromatic portion of the chromatic Fourier designmatrix" is not related to 
+    Note that the "achromatic portion of the chromatic Fourier designmatrix" is not related to
     the red noise and curn Fourier design matrices.
 
     :param toas: vector of time series in seconds
@@ -332,7 +333,8 @@ def construct_chromatic_cached_parts(
 
 
 @function
-def createfourierdesignmatrix_chromatic_with_additional_caching(fmat_red=None, Ffreqs=None, fref_over_radio_freqs=None, alpha=4.0):
+def createfourierdesignmatrix_chromatic_with_additional_caching(fmat_red=None, Ffreqs=None,
+                                                                fref_over_radio_freqs=None, alpha=4.0):
     """
     Construct Scattering-variation fourier design matrix with a cached achromatic component of the
     Fourier design matrix (fmat_red). (Note this is independent of the actual achroamtic basis.)

--- a/tests/test_gp_priors.py
+++ b/tests/test_gp_priors.py
@@ -18,6 +18,9 @@ from enterprise.signals import parameter
 from enterprise.signals import gp_signals
 from enterprise.signals import gp_priors
 from enterprise.signals import gp_bases
+from enterprise.signals import signal_base
+from enterprise.signals import white_signals
+from enterprise.signals import selections
 import scipy.stats
 
 
@@ -294,3 +297,49 @@ class TestGPSignals(unittest.TestCase):
         # test shape
         msg = "F matrix shape incorrect"
         assert rnm.get_basis(params).shape == F.shape, msg
+    
+    def test_chromatic_fourier_basis_varied_idx(self):
+        """Test the set up of variable index chromatic bases and make sure that the caching is the same as no caching"""
+        idx = parameter.Uniform(2.5, 7)
+        uncached_basis = gp_bases.createfourierdesignmatrix_chromatic(self.psr.toas,
+                                                                      self.psr.freqs,
+                                                                      nmodes=100,
+                                                                      idx=idx)
+        fmat_red, Ffreqs, fref_over_radio_freqs = gp_bases.construct_chromatic_cached_parts(self.psr.toas,
+                                                                                  self.psr.freqs,
+                                                                                  nmodes=100)
+        cached_basis = gp_bases.createfourierdesignmatrix_chromatic_with_additional_caching(fmat_red=fmat_red,
+                                                                                   Ffreqs=Ffreqs,
+                                                                                   fref_over_radio_freqs=fref_over_radio_freqs,
+                                                                                   idx=idx)
+        pr = gp_priors.powerlaw(log10_A=parameter.Uniform(-18, -11), gamma=parameter.Uniform(1, 7))
+        uncached = gp_signals.BasisGP(priorFunction=pr, basisFunction=uncached_basis, name="chrom_gp")
+        cached = gp_signals.BasisGP(priorFunction=pr, basisFunction=cached_basis, name="chrom_gp")
+        pr = gp_priors.powerlaw_genmodes(log10_A=parameter.Uniform(-18, -12), gamma=parameter.Uniform(1, 7))
+        basis = gp_bases.createfourierdesignmatrix_red(nmodes=30)
+        rn = gp_signals.BasisGP(priorFunction=pr, basisFunction=basis, name="red_noise")
+        efac = parameter.Normal(1.0, 0.1)
+        backend = selections.Selection(selections.by_backend)
+        equad = parameter.Uniform(-8.5, -5)
+        wn = white_signals.MeasurementNoise(efac=efac, log10_t2equad=equad,
+                                              selection=backend, name=None)
+        mod1 = uncached + rn + wn
+        mod2 = cached + rn + wn
+        uncached_pta = signal_base.PTA([mod1(self.psr)])
+        cached_pta = signal_base.PTA([mod2(self.psr)])
+        
+        # check that both of the chromatic bases have the chromatic index as a parameter
+        msg = "chromatic index missing from pta parameter list"
+        assert "B1855+09_chrom_gp_idx" in uncached_pta.param_names, msg
+        assert "B1855+09_chrom_gp_idx" in cached_pta.param_names, msg
+        
+        # test to make sure the likelihood evaluations agree for 10 calls
+        msg = "the likelihood from cached chromatic basis disagrees with the uncached chroamtic basis likelihood"
+        x0 = [np.hstack([p.sample() for p in cached_pta.params]) for _ in range(10)]
+        no_cache_lnlike = [uncached_pta.get_lnlikelihood(x0[i] ) for i in range(10)]
+        cache_lnlike = [cached_pta.get_lnlikelihood(x0[i] ) for i in range(10)]
+        assert np.all(no_cache_lnlike == cache_lnlike), msg
+
+        # check that both the cached and the uncached basis yield the same basis
+        msg = "the cached chromatic basis does not match the uncached chromatic basis"
+        assert np.all(uncached_pta.get_basis(params={})[0] == cached_pta.get_basis(params={})[0]), msg


### PR DESCRIPTION
This PR adds the ability to cache portions of the construction of the chromatic Fourier design matrix. 
Initially testing on NG15yr data shows a 10x speed up to the recalculation of the chromatic Fmat construction.
This constitutes anywhere between a 3% to 15% speed up of the overall likelihood calculation for single pulsar noise when sampling in the chromatic index, alpha.

As the function docstrings say, the actual caching occurs via the `@function` decorator, which now wraps the later function, caching the initially passed arguments which include the achromatic portion of the Fourier design matrix and the division of TOA observational frequencies by a reference frequency.

This does not play well with the custom noise blocks in `enterprise_extensions` which generically set up chromatic noise as such it can only be set up on a per-pulsar basis.