### PR TITLE
Switched test_orf to nside=16 to decrease memory footprint

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -214,7 +214,7 @@ class TestUtils(unittest.TestCase):
         anis_basis = anis.anis_basis(psr_positions, lmax=1, nside=8)
         anis_orf = round(utils.anis_orf(p1, p2, [0.0, 1.0, 0.0], anis_basis=anis_basis, psrs_pos=[p1, p2], lmax=1), 3)
         #anis_orf_exp = -0.150   <-- for nside=16, for nside=8 -0.152
-        anis_orf_exp = -0.150
+        anis_orf_exp = -0.152
         #
 
         msg = "ORF cross term incorrect for {}"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -186,7 +186,7 @@ class TestUtils(unittest.TestCase):
         mp_exp = 1.0 + 1e-5
         #
         psr_positions = np.array([[1.318116071652818, 2.2142974355881808], [1.1372584174390601, 0.79539883018414359]])
-        anis_basis = anis.anis_basis(psr_positions, lmax=1, nside=4)
+        anis_basis = anis.anis_basis(psr_positions, lmax=1, nside=8)
         anis_orf = round(utils.anis_orf(p1, p1, [0.0, 1.0, 0.0], anis_basis=anis_basis, psrs_pos=[p1, p2], lmax=1), 3)
         anis_orf_exp = 1.147
         #
@@ -210,7 +210,7 @@ class TestUtils(unittest.TestCase):
         mp_exp = 1.0
         #
         psr_positions = np.array([[1.318116071652818, 2.2142974355881808], [1.1372584174390601, 0.79539883018414359]])
-        anis_basis = anis.anis_basis(psr_positions, lmax=1, nside=4)
+        anis_basis = anis.anis_basis(psr_positions, lmax=1, nside=8)
         anis_orf = round(utils.anis_orf(p1, p2, [0.0, 1.0, 0.0], anis_basis=anis_basis, psrs_pos=[p1, p2], lmax=1), 3)
         anis_orf_exp = -0.150
         #

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -213,6 +213,7 @@ class TestUtils(unittest.TestCase):
         psr_positions = np.array([[1.318116071652818, 2.2142974355881808], [1.1372584174390601, 0.79539883018414359]])
         anis_basis = anis.anis_basis(psr_positions, lmax=1, nside=8)
         anis_orf = round(utils.anis_orf(p1, p2, [0.0, 1.0, 0.0], anis_basis=anis_basis, psrs_pos=[p1, p2], lmax=1), 3)
+        #anis_orf_exp = -0.150   <-- for nside=16, for nside=8 -0.152
         anis_orf_exp = -0.150
         #
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,7 +10,6 @@ Tests for `utils` module.
 
 import os
 import unittest
-import pytest
 
 import numpy as np
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -213,7 +213,7 @@ class TestUtils(unittest.TestCase):
         psr_positions = np.array([[1.318116071652818, 2.2142974355881808], [1.1372584174390601, 0.79539883018414359]])
         anis_basis = anis.anis_basis(psr_positions, lmax=1, nside=8)
         anis_orf = round(utils.anis_orf(p1, p2, [0.0, 1.0, 0.0], anis_basis=anis_basis, psrs_pos=[p1, p2], lmax=1), 3)
-        #anis_orf_exp = -0.150   <-- for nside=16, for nside=8 -0.152
+        # anis_orf_exp = -0.150   <-- for nside=16, for nside=8 -0.152
         anis_orf_exp = -0.152
         #
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -186,9 +186,9 @@ class TestUtils(unittest.TestCase):
         mp_exp = 1.0 + 1e-5
         #
         psr_positions = np.array([[1.318116071652818, 2.2142974355881808], [1.1372584174390601, 0.79539883018414359]])
-        anis_basis = anis.anis_basis(psr_positions, lmax=1, nside=8)
+        anis_basis = anis.anis_basis(psr_positions, lmax=1, nside=4)
         anis_orf = round(utils.anis_orf(p1, p1, [0.0, 1.0, 0.0], anis_basis=anis_basis, psrs_pos=[p1, p2], lmax=1), 3)
-        # anis_orf_exp = 1.147   <-- for nside=16, for nside=8 1.46
+        # anis_orf_exp = 1.147   <-- for nside=16, for nside=8,4 1.46
         anis_orf_exp = 1.146
         #
 
@@ -211,10 +211,11 @@ class TestUtils(unittest.TestCase):
         mp_exp = 1.0
         #
         psr_positions = np.array([[1.318116071652818, 2.2142974355881808], [1.1372584174390601, 0.79539883018414359]])
-        anis_basis = anis.anis_basis(psr_positions, lmax=1, nside=8)
+        anis_basis = anis.anis_basis(psr_positions, lmax=1, nside=4)
         anis_orf = round(utils.anis_orf(p1, p2, [0.0, 1.0, 0.0], anis_basis=anis_basis, psrs_pos=[p1, p2], lmax=1), 3)
         # anis_orf_exp = -0.150   <-- for nside=16, for nside=8 -0.152
-        anis_orf_exp = -0.152
+        # anis_orf_exp = -0.150   <-- for nside=16, for nside=4 -0.151
+        anis_orf_exp = -0.151
         #
 
         msg = "ORF cross term incorrect for {}"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -188,7 +188,8 @@ class TestUtils(unittest.TestCase):
         psr_positions = np.array([[1.318116071652818, 2.2142974355881808], [1.1372584174390601, 0.79539883018414359]])
         anis_basis = anis.anis_basis(psr_positions, lmax=1, nside=8)
         anis_orf = round(utils.anis_orf(p1, p1, [0.0, 1.0, 0.0], anis_basis=anis_basis, psrs_pos=[p1, p2], lmax=1), 3)
-        anis_orf_exp = 1.147
+        # anis_orf_exp = 1.147   <-- for nside=16, for nside=8 1.46
+        anis_orf_exp = 1.146
         #
 
         msg = "ORF auto term incorrect for {}"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -186,7 +186,7 @@ class TestUtils(unittest.TestCase):
         mp_exp = 1.0 + 1e-5
         #
         psr_positions = np.array([[1.318116071652818, 2.2142974355881808], [1.1372584174390601, 0.79539883018414359]])
-        anis_basis = anis.anis_basis(psr_positions, lmax=1, nside=16)
+        anis_basis = anis.anis_basis(psr_positions, lmax=1, nside=4)
         anis_orf = round(utils.anis_orf(p1, p1, [0.0, 1.0, 0.0], anis_basis=anis_basis, psrs_pos=[p1, p2], lmax=1), 3)
         anis_orf_exp = 1.147
         #
@@ -210,7 +210,7 @@ class TestUtils(unittest.TestCase):
         mp_exp = 1.0
         #
         psr_positions = np.array([[1.318116071652818, 2.2142974355881808], [1.1372584174390601, 0.79539883018414359]])
-        anis_basis = anis.anis_basis(psr_positions, lmax=1, nside=16)
+        anis_basis = anis.anis_basis(psr_positions, lmax=1, nside=4)
         anis_orf = round(utils.anis_orf(p1, p2, [0.0, 1.0, 0.0], anis_basis=anis_basis, psrs_pos=[p1, p2], lmax=1), 3)
         anis_orf_exp = -0.150
         #

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -170,7 +170,6 @@ class TestUtils(unittest.TestCase):
         assert np.allclose(utils.powerlaw(f, log10_A, gamma), pl), msg
         assert np.allclose(utils.turnover(f, log10_A, gamma, lf0, kappa, beta), pt), msg
 
-    @pytest.mark.skipif(IN_GITHUB_ACTIONS, reason="Test doesn't work in Github Actions due to limited memory.")
     def test_orf(self):
         """Test ORF functions."""
         p1 = np.array([0.3, 0.648, 0.7])
@@ -188,7 +187,7 @@ class TestUtils(unittest.TestCase):
         mp_exp = 1.0 + 1e-5
         #
         psr_positions = np.array([[1.318116071652818, 2.2142974355881808], [1.1372584174390601, 0.79539883018414359]])
-        anis_basis = anis.anis_basis(psr_positions, lmax=1)
+        anis_basis = anis.anis_basis(psr_positions, lmax=1, nside=16)
         anis_orf = round(utils.anis_orf(p1, p1, [0.0, 1.0, 0.0], anis_basis=anis_basis, psrs_pos=[p1, p2], lmax=1), 3)
         anis_orf_exp = 1.147
         #
@@ -212,7 +211,7 @@ class TestUtils(unittest.TestCase):
         mp_exp = 1.0
         #
         psr_positions = np.array([[1.318116071652818, 2.2142974355881808], [1.1372584174390601, 0.79539883018414359]])
-        anis_basis = anis.anis_basis(psr_positions, lmax=1)
+        anis_basis = anis.anis_basis(psr_positions, lmax=1, nside=16)
         anis_orf = round(utils.anis_orf(p1, p2, [0.0, 1.0, 0.0], anis_basis=anis_basis, psrs_pos=[p1, p2], lmax=1), 3)
         anis_orf_exp = -0.150
         #


### PR DESCRIPTION
This decreases the memory footprint of `test_orf` so that github actions may run on it.