### PR TITLE
Fix metadata iteration bug in FeatherPulsar class

### DIFF
--- a/enterprise/pulsar.py
+++ b/enterprise/pulsar.py
@@ -718,7 +718,7 @@ class FeatherPulsar:
             if attr in meta:
                 setattr(self, attr, meta[attr])
             else:
-                print(f"Pulsar.read_feather: cannot find {attr} in feather file {filename}.")
+                print(f"FeatherPulsar.read_feather: cannot find {attr} in feather file {filename}.")
 
         if "noisedict" in meta:
             setattr(self, "noisedict", meta["noisedict"])
@@ -758,7 +758,7 @@ class FeatherPulsar:
             if hasattr(self, attr):
                 meta[attr] = FeatherPulsar.to_list(getattr(self, attr))
             else:
-                print(f"Pulsar.save_feather: cannot find {attr} in Pulsar {self.name}.")
+                print(f"FeatherPulsar.save_feather: cannot find {attr} in Pulsar {self.name}.")
 
         # use attribute if present
         noisedict = getattr(self, "noisedict", None) if noisedict is None else noisedict

--- a/enterprise/pulsar.py
+++ b/enterprise/pulsar.py
@@ -754,9 +754,9 @@ class FeatherPulsar:
         pydict.update({f"flags_{flag}": self.flags[flag] for flag in self.flags})
 
         meta = {}
-        for attr in Pulsar.metadata:
+        for attr in FeatherPulsar.metadata:
             if hasattr(self, attr):
-                meta[attr] = Pulsar.to_list(getattr(self, attr))
+                meta[attr] = FeatherPulsar.to_list(getattr(self, attr))
             else:
                 print(f"Pulsar.save_feather: cannot find {attr} in Pulsar {self.name}.")
 


### PR DESCRIPTION
This PR fixes a bug in metadata iteration in `save_feather` function of `class FeatherPulsar`.

The original code:
```
meta = {}
for attr in Pulsar.metadata:
    if hasattr(self, attr):
        meta[attr] = Pulsar.to_list(getattr(self, attr))
    else:
        print(f"Pulsar.save_feather: cannot find {attr} in Pulsar {self.name}.")
```
was changed to
```
meta = {}
for attr in FeatherPulsar.metadata:
    if hasattr(self, attr):
        meta[attr] = FeatherPulsar.to_list(getattr(self, attr))
    else:
        print(f"FeatherPulsar.save_feather: cannot find {attr} in Pulsar {self.name}.")
```

The message in `read_feather` function:
```
print(f"Pulsar.read_feather: cannot find {attr} in feather file {filename}.")
```
was also changed to
```
print(f"FeatherPulsar.read_feather: cannot find {attr} in feather file {filename}.")
```