### PR TITLE
Add sqrtN solve for sherman-morrison and white noise kernels

### DIFF
--- a/enterprise/signals/gp_signals.py
+++ b/enterprise/signals/gp_signals.py
@@ -891,8 +891,9 @@ class MarginalizingNmat(object):
             raise NotImplementedError("MarginalizingNmat does not implement _sqrtsolve_xD1")
         elif other.ndim == 2:
             if left_array is None:
-                raise NotImplementedError("MarginalizingNmat does not implement _sqrtsolve_D2.\n"
-                                          "Perhaps use 'TimingModel'?")
+                raise NotImplementedError(
+                    "MarginalizingNmat does not implement _sqrtsolve_D2.\n" "Perhaps use 'TimingModel'?"
+                )
             elif left_array is not None and left_array.ndim == 2:
                 raise NotImplementedError("MarginalizingNmat does not implement _sqrtsolve_2D2")
             elif left_array is not None and left_array.ndim == 1:

--- a/enterprise/signals/gp_signals.py
+++ b/enterprise/signals/gp_signals.py
@@ -885,3 +885,19 @@ class MarginalizingNmat(object):
             return LNT - np.tensordot(self.MNF(L), self.MNMMNF(T), (0, 0))
         else:
             raise ValueError("Incorrect arguments given to MarginalizingNmat.solve.")
+
+    def sqrtsolve(self, other, left_array=None):
+        if other.ndim == 1:
+            raise NotImplementedError("MarginalizingNmat does not implement _sqrtsolve_xD1")
+        elif other.ndim == 2:
+            if left_array is None:
+                raise NotImplementedError("MarginalizingNmat does not implement _sqrtsolve_D2.\n"
+                                          "Perhaps use 'TimingModel'?")
+            elif left_array is not None and left_array.ndim == 2:
+                raise NotImplementedError("MarginalizingNmat does not implement _sqrtsolve_2D2")
+            elif left_array is not None and left_array.ndim == 1:
+                raise NotImplementedError("MarginalizingNmat does not implement _sqrtsolve_1D2")
+            else:
+                raise TypeError
+        else:
+            raise TypeError

--- a/enterprise/signals/gp_signals.py
+++ b/enterprise/signals/gp_signals.py
@@ -823,6 +823,7 @@ class MarginalizingNmat(object):
     def __init__(self, Mmat, Nmat=0):
         self.Mmat, self.Nmat = Mmat, Nmat
         self.Mprior = Mmat.shape[1] * np.log(1e40)
+        self._has_sqrtsolve = False
 
     def __add__(self, other):
         if isinstance(other, MarginalizingNmat):

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -1297,13 +1297,13 @@ class ShermanMorrison(object):
     def _sqrtsolve_D2(self, x):
         """Solves :math:`N^{-1/2}x` where :math:`x` is a 2-d array."""
 
-        Lix = x / np.sqrt(self._nvec[:,None])
+        Lix = x / np.sqrt(self._nvec[:, None])
         for idx, jv in zip(self._idxs, self._jvec):
-            Xblock = x[idx,:]
+            Xblock = x[idx, :]
             Nblock = np.diag(self._nvec[idx])
             Nblock += jv * np.ones_like(Nblock)
             Lblock = sl.cholesky(Nblock, lower=True)
-            Lix[idx,:] = sl.solve_triangular(Lblock, Xblock, trans=0, lower=True)
+            Lix[idx, :] = sl.solve_triangular(Lblock, Xblock, trans=0, lower=True)
 
         return Lix
 

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -1144,7 +1144,7 @@ class ndarray_alt(np.ndarray):
         if left_array is not None:
             mult = np.dot(left_array.T, mult)
 
-        return ret
+        return mult
 
 
 class BlockMatrix(object):
@@ -1297,15 +1297,15 @@ class ShermanMorrison(object):
     def _sqrtsolve_D2(self, x):
         """Solves :math:`N^{-1/2}x` where :math:`x` is a 2-d array."""
 
-        Nx = np.zeros_like(x)
+        Lix = x / np.sqrt(self._nvec[:,None])
         for idx, jv in zip(self._idxs, self._jvec):
             Xblock = x[idx,:]
             Nblock = np.diag(self._nvec[idx])
             Nblock += jv * np.ones_like(Nblock)
             Lblock = sl.cholesky(Nblock, lower=True)
-            Nx[idx,:] = sl.solve_triangular(Lblock, Xblock, trans=0, lower=True)
+            Lix[idx,:] = sl.solve_triangular(Lblock, Xblock, trans=0, lower=True)
 
-        return Nx
+        return Lix
 
     def _solve_2D2(self, X, Z):
         """Solves :math:`Z^T N^{-1}X`, where :math:`X`

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -1136,6 +1136,16 @@ class ndarray_alt(np.ndarray):
         ret = (mult, float(np.sum(np.log(self)))) if logdet else mult
         return ret
 
+    def sqrtsolve(self, other, left_array=None):
+        if other.ndim == 1:
+            mult = np.array(other / np.sqrt(self))
+        elif other.ndim == 2:
+            mult = np.array(other / np.sqrt(self[:, None]))
+        if left_array is not None:
+            mult = np.dot(left_array.T, mult)
+
+        return ret
+
 
 class BlockMatrix(object):
     def __init__(self, blocks, slices, nvec=0):
@@ -1284,6 +1294,19 @@ class ShermanMorrison(object):
                 yNx -= beta * np.dot(niblock, xblock) * np.dot(niblock, yblock)
         return yNx
 
+    def _sqrtsolve_D2(self, x):
+        """Solves :math:`N^{-1/2}x` where :math:`x` is a 2-d array."""
+
+        Nx = np.zeros_like(x)
+        for idx, jv in zip(self._idxs, self._jvec):
+            Xblock = x[idx,:]
+            Nblock = np.diag(self._nvec[idx])
+            Nblock += jv * np.ones_like(Nblock)
+            Lblock = sl.cholesky(Nblock, lower=True)
+            Nx[idx,:] = sl.solve_triangular(Lblock, Xblock, trans=0, lower=True)
+
+        return Nx
+
     def _solve_2D2(self, X, Z):
         """Solves :math:`Z^T N^{-1}X`, where :math:`X`
         and :math:`Z` are 2-d arrays.
@@ -1336,3 +1359,27 @@ class ShermanMorrison(object):
             raise TypeError
 
         return (ret, self._get_logdet()) if logdet else ret
+
+    def sqrtsolve(self, other, left_array=None):
+        if other.ndim == 1:
+            shape = other.shape
+            ret = self._sqrtsolve_D2(other.reshape(-1, 1)).reshape(*shape)
+
+            if left_array is not None and left_array.ndim == 1:
+                ret = np.sum(left_array * ret)
+            elif left_array is not None:
+                raise NotImplementedError("ShermanMorrison does not implement _sqrtsolve_1D2")
+
+        elif other.ndim == 2:
+            if left_array is None:
+                ret = self._sqrtsolve_D2(other)
+            elif left_array is not None and left_array.ndim == 2:
+                raise NotImplementedError("ShermanMorrison does not implement _sqrtsolve_2D2")
+            elif left_array is not None and left_array.ndim == 1:
+                raise NotImplementedError("ShermanMorrison does not implement _sqrtsolve_1D2")
+            else:
+                raise TypeError
+        else:
+            raise TypeError
+
+        return ret

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -1080,6 +1080,10 @@ class csc_matrix_alt(sps.csc_matrix):
     ``solve`` methods.
     """
 
+    def __init__(self, arg1, shape=None, dtype=None, copy=False):
+        super(csc_matrix_alt, self).__init__(arg1, shape=shape, dtype=dtype, copy=copy)
+        self._has_sqrtsolve = False
+
     def _add_diag(self, other):
         other_diag = sps.dia_matrix((other, np.array([0])), shape=(other.shape[0], other.shape[0]))
         return self._binopt(other_diag, "_plus_")
@@ -1106,6 +1110,10 @@ class csc_matrix_alt(sps.csc_matrix):
         ret = (mult, cf.logdet()) if logdet else mult
         return ret
 
+    def sqrtsolve(self, other, left_array=None):
+
+        raise NotImplementedError("csc_matrix_alt does not implement sqrtsolve")
+
 
 class ndarray_alt(np.ndarray):
     """Sub-class of ``np.ndarray`` with custom ``solve`` method."""
@@ -1115,6 +1123,7 @@ class ndarray_alt(np.ndarray):
             raise NotImplementedError("ndarray_alt does not support non-diagonal arrays")
 
         obj = np.asarray(inputarr).view(cls)
+        obj._has_sqrtsolve = True
 
         return obj
 
@@ -1153,6 +1162,7 @@ class BlockMatrix(object):
         self._slices = slices
         self._idxs = [indices_from_slice(slc) for slc in slices]
         self._nvec = nvec
+        self._has_sqrtsolve = False
 
         if np.any(nvec != 0):
             s1 = set(np.arange(len(nvec)))
@@ -1245,6 +1255,10 @@ class BlockMatrix(object):
 
         return (ret, self._get_logdet()) if logdet else ret
 
+    def sqrtsolve(self, other, left_array=None):
+
+        raise NotImplementedError("BlockMatrix does not implement sqrtsolve")
+
 
 class ShermanMorrison(object):
     """Custom container class for Sherman-morrison array inversion."""
@@ -1254,6 +1268,7 @@ class ShermanMorrison(object):
         self._slices = slices
         self._idxs = [indices_from_slice(slc) for slc in slices]
         self._nvec = nvec
+        self._has_sqrtsolve = True
 
     def __add__(self, other):
         nvec = self._nvec + other
@@ -1368,7 +1383,7 @@ class ShermanMorrison(object):
             if left_array is not None and left_array.ndim == 1:
                 ret = np.sum(left_array * ret)
             elif left_array is not None:
-                raise NotImplementedError("ShermanMorrison does not implement _sqrtsolve_1D2")
+                raise NotImplementedError("ShermanMorrison does not implement _sqrtsolve_2D1")
 
         elif other.ndim == 2:
             if left_array is None:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,4 +15,4 @@ pytest-cov>=2.7.0
 coverage-conditional-plugin>=0.4.0
 jupyter>=1.0.0
 build==0.3.1.post1
-fastshermanmorrison-pulsar>=0.4.0
+fastshermanmorrison-pulsar>=0.5.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,4 +15,4 @@ pytest-cov>=2.7.0
 coverage-conditional-plugin>=0.4.0
 jupyter>=1.0.0
 build==0.3.1.post1
-fastshermanmorrison-pulsar>=0.5.2
+fastshermanmorrison-pulsar>=0.5.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,4 +15,4 @@ pytest-cov>=2.7.0
 coverage-conditional-plugin>=0.4.0
 jupyter>=1.0.0
 build==0.3.1.post1
-fastshermanmorrison-pulsar>=0.5.0
+fastshermanmorrison-pulsar>=0.5.2

--- a/tests/test_white_signals.py
+++ b/tests/test_white_signals.py
@@ -22,11 +22,26 @@ from tests.enterprise_test_data import datadir
 from tests.enterprise_test_data import LIBSTEMPO_INSTALLED, PINT_INSTALLED
 
 
+def pack_indices(idxs):
+    slc_isort = np.concatenate(idxs)
+
+    lengths = [len(x) for x in idxs]
+    starts = np.cumsum([0] + lengths[:-1])
+    stops = np.cumsum(lengths)
+
+    new_Uinds = np.column_stack([starts, stops])
+
+    return slc_isort, new_Uinds
+
+
 class Woodbury(object):
     def __init__(self, N, U, J):
         self.N = N
         self.U = U
         self.J = J
+
+    def get_packing(self):
+        return pack_indices([np.where(u)[0] for u in self.U.T])
 
     def solve(self, other):
         if other.ndim == 1:
@@ -42,6 +57,47 @@ class Woodbury(object):
         else:
             tmp = np.dot(self.U, sl.cho_solve(cf, UNx)) / self.N[:, None]
         return Nx - tmp
+
+    def sqrtsolve(self, other):
+        # Use a rank-one update, instead of scipy.linalg.cholesky
+        other_shape = other.shape
+        X = other if other.ndim == 2 else other.reshape(-1, 1)
+        slc_isort, Uinds = self.get_packing()
+
+        Lix = X / np.sqrt(self.N)[:, None]
+        for bi, jv in enumerate(self.J):
+            idx0, idx1 = Uinds[bi]
+            k = idx1 - idx0
+            Xb = np.zeros((k, X.shape[1]))
+            d = np.zeros(k)
+            for i in range(k):
+                pos = slc_isort[idx0 + i]
+                Xb[i, :] = X[pos, :]
+                d[i] = self.N[pos]
+
+            L = np.diag(np.sqrt(d))
+            w = np.sqrt(jv) * np.ones(k)
+            for i in range(k):
+                r = np.hypot(L[i, i], w[i])
+                c = r / L[i, i]
+                s = w[i] / L[i, i]
+                L[i, i] = r
+                if i + 1 < k:
+                    Li1 = L[i + 1 :, i]
+                    wi1 = w[i + 1 :]
+                    L[i + 1 :, i] = (Li1 + s * wi1) / c
+                    w[i + 1 :] = c * wi1 - s * L[i + 1 :, i]
+
+            Yb = Xb.copy()
+            for i in range(k):
+                Yb[i, :] /= L[i, i]
+                if i + 1 < k:
+                    Yb[i + 1 :, :] -= np.outer(L[i + 1 :, i], Yb[i, :])
+            for i in range(k):
+                pos = slc_isort[idx0 + i]
+                Lix[pos, :] = Yb[i, :]
+
+        return Lix.reshape(*other_shape)
 
     def logdet(self):
         Sigma = np.diag(1 / self.J) + np.dot(self.U.T, self.U / self.N[:, None])
@@ -393,6 +449,25 @@ class TestWhiteSignals(unittest.TestCase):
         msg = "EFAC/ECORR {} 2D2 solve incorrect.".format(method)
         assert np.allclose(N.solve(T, left_array=T), np.dot(T.T, wd.solve(T)), rtol=1e-10), msg
 
+        msg = "EFAC/ECORR {} D2 sqrtsolve incorrect.".format(method)
+        if N._has_sqrtsolve:
+            assert np.allclose(N.sqrtsolve(T), wd.sqrtsolve(T), rtol=1e-10), msg
+
+        msg = "EFAC/ECORR {} 1D1 sqrtsolve incorrect.".format(method)
+        if N._has_sqrtsolve:
+            assert np.allclose(
+                N.sqrtsolve(T[:, 0], left_array=T[:, 0]), np.sum(T[:, 0] * wd.sqrtsolve(T[:, 0])), rtol=1e-10
+            ), msg
+
+        with self.assertRaises(NotImplementedError):
+            N.sqrtsolve(T, left_array=T)
+
+        with self.assertRaises(NotImplementedError):
+            N.sqrtsolve(T, left_array=T[:, 0])
+
+        with self.assertRaises(NotImplementedError):
+            N.sqrtsolve(T[:, 0], left_array=T)
+
     def _ecorr_test_ipta(self, method="sparse", shuffled=False):
         """Test of sparse/sherman-morrison ecorr signal and solve methods."""
         if shuffled:
@@ -473,6 +548,25 @@ class TestWhiteSignals(unittest.TestCase):
 
         msg = "EFAC/ECORR {} 2D2 solve incorrect.".format(method)
         assert np.allclose(N.solve(T, left_array=T), np.dot(T.T, wd.solve(T)), rtol=1e-8), msg
+
+        msg = "EFAC/ECORR {} D2 sqrtsolve incorrect.".format(method)
+        if N._has_sqrtsolve:
+            assert np.allclose(N.sqrtsolve(T), wd.sqrtsolve(T), rtol=1e-10), msg
+
+        msg = "EFAC/ECORR {} 1D1 sqrtsolve incorrect.".format(method)
+        if N._has_sqrtsolve:
+            assert np.allclose(
+                N.sqrtsolve(T[:, 0], left_array=T[:, 0]), np.sum(T[:, 0] * wd.sqrtsolve(T[:, 0])), rtol=1e-10
+            ), msg
+
+        with self.assertRaises(NotImplementedError):
+            N.sqrtsolve(T, left_array=T)
+
+        with self.assertRaises(NotImplementedError):
+            N.sqrtsolve(T, left_array=T[:, 0])
+
+        with self.assertRaises(NotImplementedError):
+            N.sqrtsolve(T[:, 0], left_array=T)
 
     def test_ecorr_sparse(self):
         """Test of sparse ecorr signal and solve methods."""


### PR DESCRIPTION
Let `N` be the white noise kernel (`marginalizingNmat`, `ShermanMorrison`, `ndarray_alt`, ...). The `solve(x)` method would calculate `N^{-1}x`. Assume that `LL^T=N` with `L` a Cholesky factor. Then the new `sqrtsolve(x)` would return `L^{-1}x`

This PR implements that