### PR TITLE
Bugfix: add flat powerlaw to gp_priors.py

### DIFF
--- a/enterprise/signals/gp_priors.py
+++ b/enterprise/signals/gp_priors.py
@@ -14,7 +14,9 @@ import enterprise.constants as const
 @function
 def powerlaw(f, log10_A=-16, gamma=5, components=2):
     df = np.diff(np.concatenate((np.array([0]), f[::components])))
-    return (10**log10_A) ** 2 / 12.0 / np.pi**2 * const.fyr ** (gamma - 3) * f ** (-gamma) * np.repeat(df, components)
+    return (
+        (10**log10_A) ** 2 / 12.0 / np.pi**2 * const.fyr ** (gamma - 3) * f ** (-gamma) * np.repeat(df, components)
+    )
 
 
 @function
@@ -143,7 +145,9 @@ def powerlaw_genmodes(f, log10_A=-16, gamma=5, components=2, wgts=None):
         df = wgts**2
     else:
         df = np.diff(np.concatenate((np.array([0]), f[::components])))
-    return (10**log10_A) ** 2 / 12.0 / np.pi**2 * const.fyr ** (gamma - 3) * f ** (-gamma) * np.repeat(df, components)
+    return (
+        (10**log10_A) ** 2 / 12.0 / np.pi**2 * const.fyr ** (gamma - 3) * f ** (-gamma) * np.repeat(df, components)
+    )
 
 
 @function

--- a/enterprise/signals/gp_priors.py
+++ b/enterprise/signals/gp_priors.py
@@ -14,9 +14,7 @@ import enterprise.constants as const
 @function
 def powerlaw(f, log10_A=-16, gamma=5, components=2):
     df = np.diff(np.concatenate((np.array([0]), f[::components])))
-    return (
-        (10**log10_A) ** 2 / 12.0 / np.pi**2 * const.fyr ** (gamma - 3) * f ** (-gamma) * np.repeat(df, components)
-    )
+    return (10**log10_A) ** 2 / 12.0 / np.pi**2 * const.fyr ** (gamma - 3) * f ** (-gamma) * np.repeat(df, components)
 
 
 @function
@@ -145,9 +143,7 @@ def powerlaw_genmodes(f, log10_A=-16, gamma=5, components=2, wgts=None):
         df = wgts**2
     else:
         df = np.diff(np.concatenate((np.array([0]), f[::components])))
-    return (
-        (10**log10_A) ** 2 / 12.0 / np.pi**2 * const.fyr ** (gamma - 3) * f ** (-gamma) * np.repeat(df, components)
-    )
+    return (10**log10_A) ** 2 / 12.0 / np.pi**2 * const.fyr ** (gamma - 3) * f ** (-gamma) * np.repeat(df, components)
 
 
 @function
@@ -159,5 +155,5 @@ def infinitepower(f):
 def flat_powerlaw(f, log10_A=-16, gamma=5, log10_B=-10, components=2):
     df = np.diff(np.concatenate((np.array([0]), f[::components])))
     return np.repeat(df, components) * (
-        (10 ** log10_A) ** 2 / 12.0 / np.pi ** 2 * const.fyr ** (gamma - 3) * f ** (-gamma) + 10 ** log10_B
+        (10**log10_A) ** 2 / 12.0 / np.pi**2 * const.fyr ** (gamma - 3) * f ** (-gamma) + 10**log10_B
     )

--- a/enterprise/signals/gp_priors.py
+++ b/enterprise/signals/gp_priors.py
@@ -153,3 +153,11 @@ def powerlaw_genmodes(f, log10_A=-16, gamma=5, components=2, wgts=None):
 @function
 def infinitepower(f):
     return np.full_like(f, 1e40, dtype="d")
+
+
+@function
+def flat_powerlaw(f, log10_A=-16, gamma=5, log10_B=-10, components=2):
+    df = np.diff(np.concatenate((np.array([0]), f[::components])))
+    return np.repeat(df, components) * (
+        (10 ** log10_A) ** 2 / 12.0 / np.pi ** 2 * const.fyr ** (gamma - 3) * f ** (-gamma) + 10 ** log10_B
+    )

--- a/tests/test_gp_priors.py
+++ b/tests/test_gp_priors.py
@@ -294,3 +294,33 @@ class TestGPSignals(unittest.TestCase):
         # test shape
         msg = "F matrix shape incorrect"
         assert rnm.get_basis(params).shape == F.shape, msg
+
+    def test_flat_powerlaw_prior(self):
+        """Test that red noise signal returns correct values."""
+        # set up signal parameter
+        pr = gp_priors.flat_powerlaw(log10_A=parameter.Uniform(-18, -12), gamma=parameter.Uniform(1, 7), log10_B=parameter.Uniform(-10, -4))
+        basis = gp_bases.createfourierdesignmatrix_chromatic(nmodes=30)
+        rn = gp_signals.BasisGP(priorFunction=pr, basisFunction=basis, name="red_noise")
+        rnm = rn(self.psr)
+
+        # parameters
+        log10_A, gamma, log10_B = -14.5, 4.33, -9
+        params = {"B1855+09_red_noise_log10_A": log10_A, "B1855+09_red_noise_gamma": gamma, "B1855+09_red_noise_log10_B": log10_B}
+
+        # basis matrix test
+        F, f2 = gp_bases.createfourierdesignmatrix_chromatic(self.psr.toas, self.psr.freqs, nmodes=30)
+        msg = "F matrix incorrect for flat power law."
+        assert np.allclose(F, rnm.get_basis(params)), msg
+
+        # spectrum test
+        phi = gp_priors.flat_powerlaw(f2, log10_A=log10_A, gamma=gamma, log10_B=log10_B)
+        msg = "Spectrum incorrect for flat power law."
+        assert np.all(rnm.get_phi(params) == phi), msg
+
+        # inverse spectrum test
+        msg = "Spectrum inverse incorrect for flat power law."
+        assert np.all(rnm.get_phiinv(params) == 1 / phi), msg
+
+        # test shape
+        msg = "F matrix shape incorrect"
+        assert rnm.get_basis(params).shape == F.shape, msg

--- a/tests/test_gp_priors.py
+++ b/tests/test_gp_priors.py
@@ -298,14 +298,20 @@ class TestGPSignals(unittest.TestCase):
     def test_flat_powerlaw_prior(self):
         """Test that red noise signal returns correct values."""
         # set up signal parameter
-        pr = gp_priors.flat_powerlaw(log10_A=parameter.Uniform(-18, -12), gamma=parameter.Uniform(1, 7), log10_B=parameter.Uniform(-10, -4))
+        pr = gp_priors.flat_powerlaw(
+            log10_A=parameter.Uniform(-18, -12), gamma=parameter.Uniform(1, 7), log10_B=parameter.Uniform(-10, -4)
+        )
         basis = gp_bases.createfourierdesignmatrix_chromatic(nmodes=30)
         rn = gp_signals.BasisGP(priorFunction=pr, basisFunction=basis, name="red_noise")
         rnm = rn(self.psr)
 
         # parameters
         log10_A, gamma, log10_B = -14.5, 4.33, -9
-        params = {"B1855+09_red_noise_log10_A": log10_A, "B1855+09_red_noise_gamma": gamma, "B1855+09_red_noise_log10_B": log10_B}
+        params = {
+            "B1855+09_red_noise_log10_A": log10_A,
+            "B1855+09_red_noise_gamma": gamma,
+            "B1855+09_red_noise_log10_B": log10_B,
+        }
 
         # basis matrix test
         F, f2 = gp_bases.createfourierdesignmatrix_chromatic(self.psr.toas, self.psr.freqs, nmodes=30)


### PR DESCRIPTION
enterprise_extensions has a flat powerlaw model in the common_red_noise_block which tries to use a GP prior from enterprise, but it does not exist in the main or dev branches. This PR adds that GP prior.

line in enterprise extensions which calls the flat powerlaw:
https://github.com/nanograv/enterprise_extensions/blob/4e1ce072f179ceb572f593e7af15329c3f645d77/enterprise_extensions/blocks.py#L1460

flat powerlaw taken from:
https://gitlab.in2p3.fr/epta/enterprise/-/blob/master/enterprise/signals/gp_priors.py?ref_type=heads 