### PR TITLE
Fix/numpy deprecations

### DIFF
--- a/enterprise/pulsar.py
+++ b/enterprise/pulsar.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import pickle
+from importlib import resources
 
 from pyarrow import feather
 from pyarrow import Table
@@ -16,9 +17,7 @@ import numpy as np
 from ephem import Ecliptic, Equatorial
 from astropy.time import Time
 
-import enterprise
 from enterprise.signals import utils
-
 from enterprise.pulsar_inflate import PulsarInflater
 
 logger = logging.getLogger(__name__)
@@ -72,9 +71,9 @@ class BasePulsar(object):
     """Abstract Base Class for Pulsar objects."""
 
     def _get_pdist(self):
-        dfile = enterprise.__path__[0] + "/datafiles/pulsar_distances.json"
-        with open(dfile, "r") as fl:
-            pdict = json.load(fl)
+        path = resources.files("enterprise") / "datafiles/pulsar_distances.json"
+        with open(str(path), "r") as file:
+            pdict = json.load(file)
 
         if self.name[0] not in ["J", "B"]:
             if "J" + self.name in pdict:

--- a/enterprise/signals/gp_priors.py
+++ b/enterprise/signals/gp_priors.py
@@ -61,8 +61,10 @@ def t_process_adapt(f, log10_A=-15, gamma=4.33, alphas_adapt=None, nfreq=None, c
             alpha_model = np.repeat(alphas_adapt, components)
         else:
             alpha_model = np.ones_like(f)
-            alpha_model[2 * int(np.rint(nfreq))] = alphas_adapt
-            alpha_model[2 * int(np.rint(nfreq)) + 1] = alphas_adapt
+            alphas_adapt = np.repeat(alphas_adapt, 2)
+
+            nfreq_idx = 2 * int(np.rint(nfreq))
+            alpha_model[nfreq_idx : nfreq_idx + 2] = alphas_adapt
 
     return powerlaw(f, log10_A=log10_A, gamma=gamma, components=components) * alpha_model
 

--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -1209,7 +1209,7 @@ class BlockMatrix(object):
                 bx = Xblock / self._nvec[idx][:, None]
             ZNX += np.dot(Zblock.T, bx)
         ZNX += ZNXr
-        return ZNX.squeeze() if len(ZNX) > 1 else float(ZNX)
+        return ZNX.squeeze() if len(ZNX) > 1 else ZNX.astype(float)
 
     def _solve_NX(self, X):
         """Solves :math:`N^{-1}X`, where :math:`X`

--- a/enterprise/signals/utils.py
+++ b/enterprise/signals/utils.py
@@ -10,7 +10,7 @@ import numpy as np
 import scipy.linalg as sl
 import scipy.sparse as sps
 import scipy.special as ss
-from pkg_resources import Requirement, resource_filename
+from importlib import resources
 from scipy.integrate import odeint
 from scipy.interpolate import interp1d
 from sksparse.cholmod import cholesky
@@ -351,11 +351,10 @@ def make_ecc_interpolant():
     :returns: interpolant
     """
 
-    pth = resource_filename(Requirement.parse("libstempo"), "libstempo/ecc_vs_nharm.txt")
+    path = str(resources.files("libstempo") / "ecc_vs_nharm.txt")
+    data = np.loadtxt(path)
 
-    fil = np.loadtxt(pth)
-
-    return interp1d(fil[:, 0], fil[:, 1])
+    return interp1d(data[:, 0], data[:, 1])
 
 
 def get_edot(F, mc, e):


### PR DESCRIPTION
Fixing numpy v1.25 depreciations causing unit test failures in python 3.11 and 3.12 - [#10615](https://github.com/numpy/numpy/pull/10615)

This based on PR #433 -- required for unittest passing in python 3.11 and python 3.12.

**I strongly suggest pushing to `master` soon as this will cause installation errors, unless we fix numpy<1.25**