### PR TITLE
Update sqrtsolve to new fastshermanmorrison definitions

### DIFF
--- a/enterprise/signals/signal_base.py
+++ b/enterprise/signals/signal_base.py
@@ -1313,15 +1313,29 @@ class ShermanMorrison(object):
         return yNx
 
     def _sqrtsolve_D2(self, x):
-        """Solves :math:`N^{-1/2}x` where :math:`x` is a 2-d array."""
+        """Apply :math:`N^{-1/2}x` where :math:`x` is a 2-d array.
+
+        This uses the closed-form inverse-square-root for diagonal-plus-rank1
+        ECORR blocks, rather than a Cholesky factor solve.
+        """
 
         Lix = x / np.sqrt(self._nvec[:, None])
         for idx, jv in zip(self._idxs, self._jvec):
-            Xblock = x[idx, :]
-            Nblock = np.diag(self._nvec[idx])
-            Nblock += jv * np.ones_like(Nblock)
-            Lblock = sl.cholesky(Nblock, lower=True)
-            Lix[idx, :] = sl.solve_triangular(Lblock, Xblock, trans=0, lower=True)
+            d = self._nvec[idx]
+            inv_d = 1.0 / d
+            inv_sqrt_d = 1.0 / np.sqrt(d)
+
+            v = jv * np.sum(inv_d)
+            if v > 0.0:
+                t = np.sqrt(1.0 + v)
+                # Stable equivalent of (1/sqrt(1+v) - 1) / v
+                alpha = -1.0 / (t * (t + 1.0))
+            else:
+                alpha = -0.5
+
+            vtAmb = jv * np.einsum("i,ij->j", inv_d, x[idx, :])
+            scale = alpha * vtAmb
+            Lix[idx, :] += inv_sqrt_d[:, None] * scale[None, :]
 
         return Lix
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,4 +15,4 @@ pytest-cov>=2.7.0
 coverage-conditional-plugin>=0.4.0
 jupyter>=1.0.0
 build==0.3.1.post1
-fastshermanmorrison-pulsar>=0.5.3, <0.5.5
+fastshermanmorrison-pulsar>=0.5.5

--- a/tests/test_white_signals.py
+++ b/tests/test_white_signals.py
@@ -58,7 +58,7 @@ class Woodbury(object):
         return Nx - tmp
 
     def sqrtsolve(self, other):
-        # Use a rank-one update, instead of scipy.linalg.cholesky
+        # Use the closed-form rank-1 inverse-square-root update (non-Cholesky).
         other_shape = other.shape
         X = other if other.ndim == 2 else other.reshape(-1, 1)
         slc_isort, Uinds = self.get_packing()
@@ -66,35 +66,23 @@ class Woodbury(object):
         Lix = X / np.sqrt(self.N)[:, None]
         for bi, jv in enumerate(self.J):
             idx0, idx1 = Uinds[bi]
-            k = idx1 - idx0
-            Xb = np.zeros((k, X.shape[1]))
-            d = np.zeros(k)
-            for i in range(k):
-                pos = slc_isort[idx0 + i]
-                Xb[i, :] = X[pos, :]
-                d[i] = self.N[pos]
+            if idx1 <= idx0:
+                continue
+            pos = slc_isort[idx0:idx1]
+            d = self.N[pos]
+            inv_d = 1.0 / d
+            inv_sqrt_d = 1.0 / np.sqrt(d)
 
-            L = np.diag(np.sqrt(d))
-            w = np.sqrt(jv) * np.ones(k)
-            for i in range(k):
-                r = np.hypot(L[i, i], w[i])
-                c = r / L[i, i]
-                s = w[i] / L[i, i]
-                L[i, i] = r
-                if i + 1 < k:
-                    Li1 = L[i + 1 :, i]
-                    wi1 = w[i + 1 :]
-                    L[i + 1 :, i] = (Li1 + s * wi1) / c
-                    w[i + 1 :] = c * wi1 - s * L[i + 1 :, i]
+            v = jv * np.sum(inv_d)
+            if v > 0.0:
+                t = np.sqrt(1.0 + v)
+                alpha = -1.0 / (t * (t + 1.0))
+            else:
+                alpha = -0.5
 
-            Yb = Xb.copy()
-            for i in range(k):
-                Yb[i, :] /= L[i, i]
-                if i + 1 < k:
-                    Yb[i + 1 :, :] -= np.outer(L[i + 1 :, i], Yb[i, :])
-            for i in range(k):
-                pos = slc_isort[idx0 + i]
-                Lix[pos, :] = Yb[i, :]
+            vtAmb = jv * np.einsum("i,ij->j", inv_d, X[pos, :])
+            scale = alpha * vtAmb
+            Lix[pos, :] += inv_sqrt_d[:, None] * scale[None, :]
 
         return Lix.reshape(*other_shape)
 


### PR DESCRIPTION
This addresses #438 

The definition of the sqrtsolve for kernel ecorr was changed in fastshermanmorrison. This is now also adjusted in Enterprise so the tests against fastshermanmorrison do not fail.