### PR TITLE
Add idx_exclude to MarginalizingTimingModel

### DIFF
--- a/enterprise/signals/gp_signals.py
+++ b/enterprise/signals/gp_signals.py
@@ -1003,10 +1003,16 @@ def WidebandTimingModel(
     return WidebandTimingModel
 
 
-def MarginalizingTimingModel(name="marginalizing_linear_timing_model", use_svd=False, normed=True):
-    """Class factory for marginalizing (fast-likelihood) linear timing model signals."""
+def MarginalizingTimingModel(
+    name="marginalizing_linear_timing_model", use_svd=False, normed=True, idx_exclude=None
+):
+    """Class factory for marginalizing (fast-likelihood) linear timing model signals.
 
-    basisFunction = get_timing_model_basis(use_svd, normed)
+    Parameters mirror :func:`TimingModel`, including ``idx_exclude`` to drop selected
+    timing-model columns before constructing the marginalized basis.
+    """
+
+    basisFunction = get_timing_model_basis(use_svd, normed, idx_exclude)
 
     class TimingModel(signal_base.Signal):
         signal_type = "white noise"

--- a/enterprise/signals/gp_signals.py
+++ b/enterprise/signals/gp_signals.py
@@ -1003,9 +1003,7 @@ def WidebandTimingModel(
     return WidebandTimingModel
 
 
-def MarginalizingTimingModel(
-    name="marginalizing_linear_timing_model", use_svd=False, normed=True, idx_exclude=None
-):
+def MarginalizingTimingModel(name="marginalizing_linear_timing_model", use_svd=False, normed=True, idx_exclude=None):
     """Class factory for marginalizing (fast-likelihood) linear timing model signals.
 
     Parameters mirror :func:`TimingModel`, including ``idx_exclude`` to drop selected

--- a/tests/test_gp_signals.py
+++ b/tests/test_gp_signals.py
@@ -646,6 +646,54 @@ class TestGPSignals(unittest.TestCase):
         # test incompatible prescription
         self.assertRaises(ValueError, gp_signals.TimingModel, use_svd=True, normed=False)
 
+    def test_marginalizing_timing_model_idx_exclude(self):
+        """Test idx_exclude behavior for marginalizing timing model signal."""
+        # default behavior should match full normalized timing-model matrix
+        ts = gp_signals.MarginalizingTimingModel()
+        tm = ts(self.psr)
+        nmat = tm.get_ndiag({})
+
+        full_expected = self.psr.Mmat.copy()
+        full_norm = np.sqrt(np.sum(full_expected**2, axis=0))
+        full_expected /= full_norm
+
+        msg = "Marginalizing timing-model matrix shape incorrect"
+        assert nmat.Mmat.shape == self.psr.Mmat.shape, msg
+
+        msg = "Marginalizing timing-model matrix incorrect for default behavior"
+        assert np.allclose(nmat.Mmat, full_expected), msg
+
+        # excluded-column behavior should match normalized matrix with columns removed
+        idx_exclude = [0, 2]
+        ts = gp_signals.MarginalizingTimingModel(idx_exclude=idx_exclude)
+        tm = ts(self.psr)
+        nmat = tm.get_ndiag({})
+
+        keep = np.array([ii for ii in range(self.psr.Mmat.shape[1]) if ii not in idx_exclude])
+        ex_expected = self.psr.Mmat[:, keep].copy()
+        ex_norm = np.sqrt(np.sum(ex_expected**2, axis=0))
+        ex_expected /= ex_norm
+        ex_expected[:, ex_norm == 0] = 0
+
+        msg = "Excluded-column marginalizing timing-model shape incorrect"
+        assert nmat.Mmat.shape == ex_expected.shape, msg
+
+        msg = "Excluded-column marginalizing timing-model matrix incorrect"
+        assert np.allclose(nmat.Mmat, ex_expected), msg
+
+        # ensure exclusion is applied before SVD basis generation
+        ts = gp_signals.MarginalizingTimingModel(use_svd=True, idx_exclude=idx_exclude)
+        tm = ts(self.psr)
+        nmat = tm.get_ndiag({})
+
+        u, _, _ = np.linalg.svd(self.psr.Mmat[:, keep], full_matrices=False)
+
+        msg = "SVD excluded-column marginalizing timing-model shape incorrect"
+        assert nmat.Mmat.shape == u.shape, msg
+
+        msg = "SVD excluded-column marginalizing timing-model matrix incorrect"
+        assert np.allclose(np.abs(nmat.Mmat), np.abs(u)), msg
+
     def test_pshift_fourier(self):
         """Test Fourier basis with prescribed phase shifts."""
 

--- a/tests/test_likelihood.py
+++ b/tests/test_likelihood.py
@@ -272,6 +272,17 @@ class TestLikelihood(unittest.TestCase):
         self.compute_like(npsrs=1)
         self.compute_like(npsrs=2)
 
+    def test_like_marginalizing_tm_idx_exclude(self):
+        """Test for marginalizing timing model with excluded columns."""
+        psr = self.psrs[0]
+
+        tm = gp_signals.MarginalizingTimingModel(idx_exclude=[0])
+        mn = white_signals.MeasurementNoise(efac=parameter.Constant(1.0))
+        pta = signal_base.PTA([(tm + mn)(psr)])
+
+        ll = pta.get_lnlikelihood({})
+        assert np.isfinite(ll), "Likelihood should be finite with idx_exclude timing model"
+
     def test_like_corr(self):
         """Test likelihood with spatial correlations."""
         for cholesky_sparse in [True, False]:


### PR DESCRIPTION
## Summary

- Adds an `idx_exclude` parameter to `MarginalizingTimingModel`, mirroring the existing API on `TimingModel`.
- Excluded columns are dropped before basis construction (including the SVD path), so the marginalized timing-model matrix only spans the remaining linear parameters.
- Adds unit tests for default behavior, column exclusion, and SVD + exclusion, plus a likelihood smoke test.

This is a small API parity change. It lets callers marginalize over a subset of timing-model columns while handling the excluded ones elsewhere — for example, when a nonlinear delay term samples some parameters and the remaining linear timing parameters are marginalized analytically.

## Test plan

- [x] `pytest tests/test_gp_signals.py::TestGPSignals::test_marginalizing_timing_model_idx_exclude`
- [x] `pytest tests/test_likelihood.py::TestLikelihood::test_like_marginalizing_tm_idx_exclude`
- [x] Full Enterprise test suite (if CI is available)