### PR TITLE
Fix parfile ELAT and ELONG interpretation

### DIFF
--- a/enterprise/pulsar.py
+++ b/enterprise/pulsar.py
@@ -135,11 +135,11 @@ class BasePulsar(object):
         try:
             ec = Ecliptic(elong, elat)
 
-            # check for B name
-            if "B" in self.name:
-                epoch = "1950"
-            else:
-                epoch = "2000"
+            # Assume elong and elat are given in J2000 coordinates.
+            # this isn't optimal, but is consistent with the values used in the parfiles
+            # circumvent this by including RAJ and DECJ in parfiles.
+            epoch = "2000"
+
             eq = Equatorial(ec, epoch=str(epoch))
             raj = np.double(eq.ra)
             decj = np.double(eq.dec)


### PR DESCRIPTION
This is a fix to issue #452 

This is mostly a temporary solution as including only ELAT and ELONG definitions in the parfile will always assume that the position epochs are in J2000 instead of switching between B1950 and J2000 depending on the pulsar name. Using RAJ and DECJ in the parfiles circumvents this issue entirely and should be preferred in the future.